### PR TITLE
Set up Hugo docs site with Altinn theme

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -29,10 +29,14 @@ jobs:
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
 
       - name: Setup Pages

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,67 @@
+name: Deploy Hugo site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.155.3
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+          TZ: Europe/Oslo
+        run: |
+          hugo \
+            --gc \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Hugo build output
 public/
 resources/_gen/
+.hugo_build.lock
 
 # Hugo module cache
 hugo_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Hugo build output
+public/
+resources/_gen/
+
+# Hugo module cache
+hugo_cache/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+.idea/
+.vscode/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/hugo-theme-altinn"]
+	path = themes/hugo-theme-altinn
+	url = https://github.com/samt-bu/hugo-theme-altinn.git

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+date = '{{ .Date }}'
+draft = true
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
++++

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,6 @@
+---
+title: "SAMT-BU Documentation"
+description: "Documentation hub for SAMT-BU"
+---
+
+Welcome to the SAMT-BU documentation site.

--- a/content/use-cases/_index.md
+++ b/content/use-cases/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Use Cases"
+description: "Use cases and scenarios"
+weight: 10
+---
+
+This section describes the use cases for SAMT-BU.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/samt-bu/samt-bu-docs
+
+go 1.24.7

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,35 @@
+baseURL = "https://samt-bu.github.io/samt-bu-docs/"
+languageCode = "en"
+title = "SAMT-BU Documentation"
+theme = "hugo-theme-altinn"
+
+enableEmoji = true
+enableGitInfo = true
+pluralizeListTitles = false
+
+[markup.goldmark.parser]
+autoHeadingIDType = "github"
+
+[markup.goldmark.parser.attribute]
+block = true
+title = true
+
+[markup.goldmark.renderer]
+unsafe = true
+
+[markup.highlight]
+style = "dracula"
+
+[markup.tableOfContents]
+startLevel = 2
+endLevel = 5
+ordered = false
+
+[params]
+editURL = "https://github.com/samt-bu/samt-bu-docs/blob/main/content/"
+noHomeIcon = true
+noSearch = false
+showVisitedLinks = false
+
+[outputs]
+home = ["HTML", "JSON"]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,108 @@
+
+                </div>
+              </div>
+
+              <div id="navigation">
+                  <!-- Next prev page -->
+                  {{ $currentNode := . }}
+                  
+                  {{ template "menu-nextprev" dict "menu" .Site.Home "currentnode" $currentNode }}
+                  
+                  {{ define "menu-nextprev" }}
+                      {{$currentNode := .currentnode }}
+                      {{ if ne .menu.Params.hidden true}}
+                          {{if hasPrefix $currentNode.RelPermalink .menu.RelPermalink }}
+                              {{ $currentNode.Scratch.Set "NextPageOK" "OK" }}
+                              {{ $currentNode.Scratch.Set "prevPage" ($currentNode.Scratch.Get "prevPageTmp") }}
+                          {{else}}
+                              {{if eq ($currentNode.Scratch.Get "NextPageOK") "OK"}}
+                                  {{ $currentNode.Scratch.Set "NextPageOK" nil }}
+                                  {{ $currentNode.Scratch.Set "nextPage" .menu }}
+                              {{end}}
+                          {{end}}
+                          {{ $currentNode.Scratch.Set "prevPageTmp" .menu }}
+          
+                              {{ $currentNode.Scratch.Set "pages" .menu.Pages }}
+                              {{ if .menu.IsHome}}
+                                  {{ $currentNode.Scratch.Set "pages" .menu.Sections }}
+                              {{ else if .menu.Sections}}
+                                  {{ $currentNode.Scratch.Set "pages" (.menu.Pages | union .menu.Sections) }}
+                              {{end}}
+                              {{ $pages := ($currentNode.Scratch.Get "pages") }}
+          
+                              {{ range $pages.ByWeight  }}
+                                  {{ template "menu-nextprev" dict "menu" . "currentnode" $currentNode }}
+                              {{end}}
+                      {{ end }}
+                  {{ end }}
+          
+          
+                  {{with ($.Scratch.Get "prevPage")}}
+                      <a class="nav nav-prev" href="{{.RelPermalink}}" title="{{.Title}}"> <i class="fa fa-angle-left"></i> Forrige side</a>
+                  {{end}}
+                  {{with ($.Scratch.Get "nextPage")}}
+                      <a class="nav nav-next" href="{{.RelPermalink}}" title="{{.Title}}" style="margin-right: 0px;">Neste side <i class="fa fa-angle-right"></i></a>
+                  {{end}}
+              </div>
+
+
+            </div><!-- End adocs-content -->
+
+            {{ if and (or .IsPage .IsSection) .Site.Params.editURL }}
+              {{ $File := .File }}
+              {{ $Site := .Site }}
+              {{with $File.Path }}
+                <div id="top-github-link">
+                  <a class="" href="{{ $Site.Params.editURL }}{{ replace $File.Dir "\\" "/" }}{{ $File.LogicalName }}" target="blank">
+                    <i class="fa fa-code-fork"></i>
+                    {{T "Edit-this-page"}}
+                  </a>
+                </div>
+              {{ end }}
+            {{ end }}
+
+        </section>
+
+
+        </div> <!-- End col-sm-12 -->
+      </div> <!-- End row -->
+    </div>
+    </div> <!-- End container -->
+
+    {{ partial "footer-content.html" . }}
+
+    <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
+      <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
+    </div>
+    <script src="{{"js/clipboard.min.js" | relURL}}"></script>
+    <script src="{{"js/html5shiv-printshiv.min.js" | relURL}}"></script>
+    <script src="{{"js/highlight.pack.js" | relURL}}"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+    <script src="{{"js/modernizr.custom.71422.js" | relURL}}"></script>
+    
+    <script src="{{"js/altinninfoportal.js" | relURL}}"></script>
+    <script src="{{"js/altinndocs.js" | relURL}}"></script>
+    <script src="{{"js/altinndocs-learn.js" | relURL}}"></script>
+
+    <script src="{{"js/stickysidebar/rAF.js" | relURL}}"></script>
+    <script src="{{"js/stickysidebar/ResizeSensor.js" | relURL}}"></script>
+    <script src="{{"js/stickysidebar/sticky-sidebar.js" | relURL}}"></script>
+    
+    <script>
+      var a = new StickySidebar('#sidebar', {
+        topSpacing: 20,
+        bottomSpacing: 60,
+        containerSelector: '.adocs-scrollcontainer',
+        innerWrapperSelector: '.sidebar__inner',
+        minWidth: 768
+      });
+    </script>
+
+    <link href="{{"mermaid/mermaid.css" | relURL}}" type="text/css" rel="stylesheet"/>
+    <script src="{{"mermaid/mermaid.js" | relURL}}"></script>
+    <script>mermaid.initialize({startOnLoad:true});</script>
+
+    {{ partial "custom-footer.html" . }}
+
+  </body>
+</html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="{{ .Page.Language | default "en" }}" class="js csstransforms3d">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {{ partial "meta.html" . }}
+    {{if .IsHome}}
+    <title>Altinn digitalisering - Utvikling</title>
+    {{else}}
+    <title>{{ .Title }} :: Altinn digitalisering - Utvikling</title>
+    {{end}}
+    <link rel="shortcut icon" href="{{"images/favicon.png" | relURL}}" type="image/x-icon" />
+    <link href="{{"css/nucleus.css" | relURL}}" rel="stylesheet">
+    <link href="{{"css/font-awesome.min.css" | relURL}}" rel="stylesheet">
+    <link href="{{"css/hybrid.css" | relURL}}" rel="stylesheet">
+    <link href="{{"css/horsey.css" | relURL}}" rel="stylesheet">
+    <link href="{{"css/fortawesome.css" | relURL}}" rel="stylesheet">
+    <link href="{{"css/designsystem.css" | relURL}}" rel="stylesheet">
+    {{with .Site.Params.themeStyle}}
+    <link href="{{(printf "css/%s.css" .) | relURL}}" rel="stylesheet">
+    {{else}}
+    <link href="{{"css/theme.css" | relURL}}" rel="stylesheet">
+    {{end}}
+    {{with .Site.Params.themeVariant}}
+      <link href="{{(printf "css/theme-%s.css" .) | relURL}}" rel="stylesheet">
+    {{end}}
+    
+    <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
+
+    {{ partial "custom-head.html" . }}
+
+    <style>
+      :root #header + #content > #left > #rlblock_left {
+        display:none !important;
+      }
+    </style>
+
+
+  </head>
+  <body class="a-page" data-url="{{ .RelPermalink }}">
+    {{ partial "topbar.html" . }}
+
+    {{ if and (.IsHome) (.Params.jumbotron) }}
+      {{ partial "jumbotron.html" . }}
+    {{end}}
+
+    <div class="container pt-2 pt-md-3 pt-lg-5">
+      <div class="adocs-scrollcontainer">
+        <div class="row">
+            <div class="col-sm-12">
+
+    {{ partial "menu.html" . }}
+        <section id="body">
+          <div id="content" class="adocs-content js-moveChildrenTo">
+        <div id="overlay"></div>
+        <div class="a-text">
+        {{if not .IsHome}}
+          <div id="top-bar">
+            
+
+            <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
+                <span id="sidebar-toggle-span" class="adocs-sidebarToggle">
+                  <a href="#" id="sidebar-toggle" data-sidebar-toggle="">
+                    <i class="fa fa-bars"></i>
+                    <span class="sr-only">Vis/skjul meny</span>
+                  </a>
+                </span>
+                <span class="links">
+                  {{if eq .Kind "taxonomy"}}
+                    <a href="/docs/tags/">Tags</a> /
+                  {{end}}
+                  {{ template "breadcrumb" dict "page" . "value" .LinkTitle }}
+                </span>
+            </div>
+          </div>
+        {{end}}
+        {{if .Params.tags }}
+          <div id="tags">
+            {{ range $index, $tag := .Params.tags }}
+              <a class="label label-default" href="{{$.Site.BaseURL}}tags/{{ $tag | urlize }}">{{ $tag }}</a>
+            {{ end }}
+          </div>
+        {{end}}
+        <div id="body-inner">
+          {{if not .IsHome}}
+            {{if eq .Kind "taxonomy"}}
+              <h1 class="a-fontBold">Tag: {{.Title}}</h1>
+            {{else}}
+              <h1 class="a-fontBold">
+                {{.Title}}
+                {{if .Params.titleSup }}
+                  <sup>{{.Params.titleSup}}</sup>
+                {{end}}
+              </h1>
+              <p class="a-leadText" id="leadText">{{.Description}}</p>
+            {{end}}
+          {{end}}
+
+          {{ if and (gt .WordCount 100 ) (.Params.toc) }}
+            <h2>På denne siden:</h2>
+              {{ .TableOfContents }}
+          {{ end }}
+
+{{define "breadcrumb"}}
+{{ if .page.Parent}}
+{{$value := (printf "<a href='%s'>%s</a> <span class='adocs-breadcrumb-divider'> / </span> %s" .page.Parent.RelPermalink .page.Parent.LinkTitle .value)}}
+{{ template "breadcrumb" dict "page" .page.Parent "value" $value }} 
+{{else}}
+ {{.value|safeHTML}}
+{{end}}
+{{end}}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,0 +1,122 @@
+<nav id="sidebar" class="{{if $.Site.Params.showVisitedLinks }}showVisitedLinks{{end}}">
+
+
+
+{{ $currentNode := . }}
+{{ $showvisitedlinks := .Site.Params.showVisitedLinks }}
+<div class="highlightable">
+  <div id="header-wrapper">
+    {{if not .Site.Params.noSearch}}
+        {{ partial "search.html" . }}
+    {{end}}
+  </div>
+
+  
+    <ul id="docsmenu" class="topics">
+        {{if not .Site.Params.noHomeIcon}}
+            <li data-nav-id="{{"/" | relURL}}" class="dd-item">
+            <a href="{{"/" | relURL}}"><i class="fa fa-fw fa-home"></i></a>
+            </li>
+        {{end}}
+        
+        {{if eq .Site.Params.ordersectionsby "title"}}  
+          {{range .Site.Home.Sections.ByTitle}}
+          {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
+          {{end}}
+        {{else}}
+          {{range .Site.Home.Sections.ByWeight}}
+          {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
+          {{end}}
+        {{end}}
+
+        {{with .Site.Menus.shortcuts}}
+        
+            {{ range sort . "Weight"}}
+                <li>
+                    {{.Pre}}
+                    <a href="{{.URL}}">{{safeHTML .Name}}</a>
+                    {{.Post}}
+                </li>
+            {{end}}
+           
+        
+        {{ if $.Site.Params.showVisitedLinks}}
+            <a class="" href="#" data-clear-history-toggle=""><i class="fa  fa-history"></i> {{T "Clear-History"}}</a>
+        {{ end }}
+
+        {{end}}
+    </ul>
+  </div>
+</nav>
+
+<!-- templates -->
+{{ define "section-tree-nav" }}
+{{ $showvisitedlinks := .showvisitedlinks }}
+{{ $currentNode := .currentnode }}
+ {{with .sect}}
+  {{if .IsSection}}
+    {{safeHTML .Params.head}}
+    <li data-nav-id="{{.RelPermalink}}" class="dd-item
+        {{if .IsAncestor $currentNode }}parent{{end}}
+        {{if eq .RelPermalink $currentNode.RelPermalink}}active{{end}}
+        {{if .Params.alwaysopen}}parent{{end}}
+        ">
+      <a href="{{ .RelPermalink}}">
+        <span>{{safeHTML .Params.Pre}}{{.LinkTitle}}{{safeHTML .Params.Post}}</span>
+
+        {{if .Params.titleSup }}
+          <sup>{{.Params.titleSup}}</sup>
+        {{end}}
+
+        {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
+        {{ if ne $numberOfPages 0 }}
+
+          {{if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
+            <i class="fa fa-sort-down fa-lg category-icon"></i>
+          {{else}}
+            <i class="fa fa-caret-right fa-lg category-icon"></i>
+          {{end}}
+
+        {{ end }}
+
+        {{ if $showvisitedlinks}}<i style="color:grey" class="fa fa-circle-thin read-icon"></i>{{end}}
+      </a>
+      {{ if ne $numberOfPages 0 }}
+        <ul>
+          {{ .Scratch.Set "pages" .Pages }}
+          {{ if .Sections}}
+          {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
+          {{end}}
+          {{ $pages := (.Scratch.Get "pages") }}
+          
+        {{if eq .Site.Params.ordersectionsby "title"}}  
+          {{ range $pages.ByTitle }}
+            {{ if and .Params.hidden (not $.showhidden) }} 
+            {{else}}
+            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+            {{end}}
+          {{ end }}
+        {{else}}
+          {{ range $pages.ByWeight }}
+            {{ if and .Params.hidden (not $.showhidden) }} 
+            {{else}}
+            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+            {{end}}
+          {{ end }}
+        {{end}}
+        </ul>
+      {{ end }}        
+    </li>
+  {{else}}
+    {{ if not .Params.Hidden }}
+      <li data-nav-id="{{.RelPermalink}}" class="dd-item
+     {{if eq .RelPermalink $currentNode.RelPermalink}}active{{end}}
+      ">
+        <a href="{{ .RelPermalink}}">
+        <span>{{safeHTML .Params.Pre}}{{.LinkTitle}}{{safeHTML .Params.Post}}</span> 
+        {{ if $showvisitedlinks}}<i style="color:grey" class="fa fa-circle-thin read-icon"></i>{{end}}
+        </a></li>
+     {{ end }}
+  {{end}}
+ {{ end }}
+{{ end }}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -1,0 +1,99 @@
+{{ $showhidden := .Get "showhidden"}}
+{{ $style :=  .Get "style" | default "li" }}
+{{ $depth :=  .Get "depth" | default 1 }}
+{{ $withDescription :=  .Get "description" | default false }}
+{{ $sortTerm :=  .Get "sort" | default "Weight" }}
+
+{{ .Scratch.Set "current" .Page }}
+
+{{if (.Get "page")}}
+	{{ with .Site.GetPage "section" (.Get "page") }}
+		{{ $.Scratch.Set "current" . }}
+	{{ end }}
+{{ end }}
+
+{{ $cpage := (.Scratch.Get "current") }}
+
+<ul class="children children-{{$style}} js-moveChildrenFrom">
+	{{ .Scratch.Set "pages" $cpage.Pages }}
+    {{ if $cpage.Sections}}
+	    {{ .Scratch.Set "pages" ($cpage.Pages | union $cpage.Sections) }}
+    {{end}}
+    {{ $pages := (.Scratch.Get "pages") }}
+
+	{{if eq $sortTerm "Weight"}}
+		{{template "childs" dict "menu" $pages.ByWeight "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else if eq $sortTerm "Name"}}
+		{{template "childs" dict "menu" $pages.ByTitle "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else if eq $sortTerm "PublishDate"}}
+		{{template "childs" dict "menu" $pages.ByPublishDate "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else if eq $sortTerm "Date"}}
+		{{template "childs" dict "menu" $pages.ByDate "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else if eq $sortTerm "Length"}}
+		{{template "childs" dict "menu" $pages.ByLength "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{else}}
+		{{template "childs" dict "menu" $pages "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{end}}
+</ul>
+
+{{.Inner|safeHTML}}
+
+{{ define "childs" }}
+	{{ range .menu }}
+		{{ if and .Params.hidden (not $.showhidden) }} 
+		{{else}}
+  
+
+{{if hasPrefix $.style "h"}}
+	{{$num := sub ( int (trim $.style "h") ) 1 }}
+	{{$numn := add $num $.count }}
+
+{{(printf "<h%d>" $numn)|safeHTML}}
+<a href="{{.RelPermalink}}" >{{ .Title }}</a>
+{{(printf "</h%d>" $numn)|safeHTML}}
+
+{{else}}
+{{(printf "<%s>" $.style)|safeHTML}}
+<a href="{{.RelPermalink}}" >{{ .Title }}</a>
+<p>{{.Description}}</p>
+{{(printf "</%s>" $.style)|safeHTML}}
+{{end}}
+
+
+
+
+
+		
+
+		
+			{{ if lt $.count $.depth}}
+{{if eq $.style "li"}}
+<ul>
+{{end}}
+	{{ .Scratch.Set "pages" .Pages }}
+    {{ if .Sections}}
+	    {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
+    {{end}}
+    {{ $pages := (.Scratch.Get "pages") }}
+
+	{{if eq $.sortTerm "Weight"}}
+		{{template "childs" dict "menu" $pages.ByWeight  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{else if eq $.sortTerm "Name"}}
+		{{template "childs" dict "menu" $pages.ByTitle  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{else if eq $.sortTerm "PublishDate"}}
+		{{template "childs" dict "menu" $pages.ByPublishDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{else if eq $.sortTerm "Date"}}
+		{{template "childs" dict "menu" $pages.ByDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{else if eq $.sortTerm "Length"}}
+		{{template "childs" dict "menu" $pages.ByLength  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{else}}
+		{{template "childs" dict "menu" $pages  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{end}}
+{{if eq $.style "li"}}
+</ul>
+{{end}}
+			{{end}}
+
+		{{end}}
+	{{end}}
+{{end}}

--- a/layouts/shortcodes/header.html
+++ b/layouts/shortcodes/header.html
@@ -1,0 +1,16 @@
+<div class="well">
+	<strong>Résumé</strong><br/>
+	{{.Inner}}
+
+	<div><strong>Sur cette page</strong></div>
+	{{.Page.TableOfContents}}
+	<div><strong>Pages liées</strong></div>
+	<ul>
+		{{ range sort .Page.Sections }}
+			<li><a href="{{.RelPermalink}}" >{{ .Title }}</a></li>
+		{{ end }}
+		{{ range sort .Page.Pages }}
+			<li><a href="{{.RelPermalink}}" >{{ .Title }}</a></li>
+		{{ end }}
+	</ul>
+</div>

--- a/layouts/shortcodes/relref.html
+++ b/layouts/shortcodes/relref.html
@@ -1,0 +1,12 @@
+{{- if in (.Get 0) "/_index.md" -}}
+	{{- $path := (trim (.Get 0) "_index.md") -}}
+	{{- with .Site.GetPage "section" (trim $path "/") -}}
+		{{- .RelPermalink -}}
+	{{- end -}}
+{{- else -}}
+	{{- with .Site.GetPage "section" (.Get 0) }}
+		{{- .RelPermalink -}}
+	{{- else -}}
+		{{- .Get 0 | relref .Page -}}
+	{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Summary
- Satt opp Hugo-dokumentasjonssiden med Altinn-temaet og norsk språk
- Lagt til layout partials (header, footer, menu) og shortcodes
- Lagt til Go-installasjon i GitHub Actions workflow slik at Hugo modules fungerer
- Utvidet .gitignore med nyttige ignores

## Test plan
- [ ] Verifiser at GitHub Actions workflow kjører uten feil etter merge
- [ ] Sjekk at siden er tilgjengelig på https://samt-bu.github.io/samt-bu-docs/
- [ ] Bekreft at Altinn-temaet lastes korrekt
