### PR TITLE
Disable Go module caching in deploy workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
+          cache: false
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The setup-go action warns about missing go.sum for caching. Since Hugo handles its own module caching, Go-level caching is unnecessary here.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx