### PR TITLE
Erstatt Altinn-bunntekst med SAMT-BU footer

### DIFF
--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -1,0 +1,11 @@
+<footer class="a-footer a-bgBlueDarker">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <nav class="a-footerExtraNav">
+                    SAMT-BU {{ now.Format "2006-01-02" }}
+                </nav>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-12">
                 <nav class="a-footerExtraNav">
-                    SAMT-BU {{ now.Format "2006-01-02" }}
+                    SAMT-BU {{ now.Format "2006-01-02 15:04:05" }}
                 </nav>
             </div>
         </div>


### PR DESCRIPTION
* Overstyrer temaets footer-content.html med en enkel versjon
* Bunnteksten viser nå kun "SAMT-BU <dato klokkeslett>" i 24-timers format med sekunder
* Fjerner Brønnøysundregistrene/Altinn-lenker som ikke er relevante