### PR TITLE
Legg til SAMT-BU logo og heading i topbar

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,10 +1,7 @@
 baseURL = "https://samt-bu.github.io/samt-bu-docs/"
 title = "SAMT-BU Dokumentasjon"
 languageCode = "nb"
-
-[module]
-  [[module.imports]]
-    path = "github.com/altinn/hugo-theme-altinn"
+theme = "hugo-theme-altinn"
 
 [params]
   # tilpasses senere

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ partial "meta.html" . }}
     {{if .IsHome}}
-    <title>Altinn digitalisering - Utvikling</title>
+    <title>{{ .Site.Title }}</title>
     {{else}}
-    <title>{{ .Title }} :: Altinn digitalisering - Utvikling</title>
+    <title>{{ .Title }} :: {{ .Site.Title }}</title>
     {{end}}
     <link rel="shortcut icon" href="{{"images/favicon.png" | relURL}}" type="image/x-icon" />
     <link href="{{"css/nucleus.css" | relURL}}" rel="stylesheet">

--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -1,0 +1,21 @@
+<nav class="a-jumpnav">
+  <ul class="no-decoration d-flex">
+    <li><a class="sr-only sr-only-focusable" href="#content">Hopp til hovedinnholdet</a></li>
+    <li><a class="sr-only sr-only-focusable" href="#docsmenu">Hopp til meny</a></li>
+  </ul>
+</nav>
+
+<header class="a-header">
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+        <nav class="a-globalNav" id="primary-nav">
+          <a href="{{ with .Site.GetPage "/" }}{{ .RelPermalink }}{{ end }}" class="a-globalNav-logo" style="display: flex; align-items: center; text-decoration: none;">
+            <img src="{{ "images/samt-bu-logo.svg" | relURL }}" alt="SAMT-BU logo" class="a-logo a-modal-top-logo" style="height: 40px; width: auto; margin-right: 10px;">
+            <span style="color: #fff; font-size: 1.8rem; font-weight: bold;">SAMT-BU Dokumentasjon</span>
+          </a>
+        </nav>
+      </div>
+    </div>
+  </div>
+</header>

--- a/static/images/samt-bu-logo.svg
+++ b/static/images/samt-bu-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <circle cx="24" cy="24" r="22" fill="#1a936f"/>
+  <text x="24" y="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="12" fill="white">SAMT</text>
+  <text x="24" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="12" fill="white">BU</text>
+</svg>


### PR DESCRIPTION
- Erstatt Altinn-logo med SAMT-BU logo og "SAMT-BU Dokumentasjon" heading
- Fiks HTML-tittel til å bruke site title fra hugo.toml
- Bytt fra Hugo modules til lokal tema-referanse for pålitelig bygging

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx