### PR TITLE
Bytt logo fra SVG-plassholder til opplastet SAMT-BU-logo.png

### DIFF
--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -11,7 +11,7 @@
       <div class="col-12">
         <nav class="a-globalNav" id="primary-nav">
           <a href="{{ with .Site.GetPage "/" }}{{ .RelPermalink }}{{ end }}" class="a-globalNav-logo" style="display: flex; align-items: center; text-decoration: none;">
-            <img src="{{ "images/samt-bu-logo.svg" | relURL }}" alt="SAMT-BU logo" class="a-logo a-modal-top-logo" style="height: 40px; width: auto; margin-right: 10px;">
+            <img src="{{ "images/SAMT-BU-logo.png" | relURL }}" alt="SAMT-BU logo" class="a-logo a-modal-top-logo" style="height: 40px; width: auto; margin-right: 10px;">
             <span style="color: #fff; font-size: 1.8rem; font-weight: bold;">SAMT-BU Dokumentasjon</span>
           </a>
         </nav>

--- a/static/images/samt-bu-logo.svg
+++ b/static/images/samt-bu-logo.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
-  <circle cx="24" cy="24" r="22" fill="#1a936f"/>
-  <text x="24" y="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="12" fill="white">SAMT</text>
-  <text x="24" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="12" fill="white">BU</text>
-</svg>


### PR DESCRIPTION
Oppdaterer topbar til å bruke det faktiske SAMT-BU-logoet og fjerner den gamle SVG-plasholderen.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx