### PR TITLE
Legg til 19 brukssaker med norsk og engelsk oversettelse

### DIFF
--- a/content/use-cases/01-resultater-vgo/_index.en.md
+++ b/content/use-cases/01-resultater-vgo/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "1. Making Results from Upper Secondary Education Accessible"
+linkTitle: "1. Results from Upper Secondary"
+weight: 1
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Making results from upper secondary education accessible.
+
+## Status
+
+Not started.

--- a/content/use-cases/01-resultater-vgo/_index.nb.md
+++ b/content/use-cases/01-resultater-vgo/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "1. Tilgjengeliggjøre resultater fra videregående opplæring"
+linkTitle: "1. Resultater fra VGO"
+weight: 1
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Tilgjengeliggjøre resultater fra videregående opplæring.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/02-overgang-grunnskole-vgo/_index.en.md
+++ b/content/use-cases/02-overgang-grunnskole-vgo/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "2. Seamless Transition from Primary to Upper Secondary Education"
+linkTitle: "2. Primary to Upper Secondary"
+weight: 2
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Seamless transition from primary to upper secondary education.
+
+## Status
+
+Not started.

--- a/content/use-cases/02-overgang-grunnskole-vgo/_index.nb.md
+++ b/content/use-cases/02-overgang-grunnskole-vgo/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "2. Sømløs overgang fra grunnskole til videregående opplæring"
+linkTitle: "2. Overgang grunnskole–VGO"
+weight: 2
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Sømløs overgang fra grunnskole til videregående opplæring.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/03-id-haandtering-flyktninger/_index.en.md
+++ b/content/use-cases/03-id-haandtering-flyktninger/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "3. ID Management for Refugees and Use of D-numbers"
+linkTitle: "3. Refugee ID Management"
+weight: 3
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+ID management for refugees and use of D-numbers (and transition to national identity numbers).
+
+## Status
+
+Not started.

--- a/content/use-cases/03-id-haandtering-flyktninger/_index.nb.md
+++ b/content/use-cases/03-id-haandtering-flyktninger/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "3. ID-håndtering av flyktninger og bruk av D-nummer"
+linkTitle: "3. ID-håndtering flyktninger"
+weight: 3
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+ID-håndtering av flyktninger og bruk av D-nummer (og overgang til fødselsnummer).
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/04-flytting-elever/_index.en.md
+++ b/content/use-cases/04-flytting-elever/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "4. Student Relocation Between Municipalities During the School Year"
+linkTitle: "4. Student Relocation"
+weight: 4
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Student relocation between municipalities and county municipalities during the school year.
+
+## Status
+
+Not started.

--- a/content/use-cases/04-flytting-elever/_index.nb.md
+++ b/content/use-cases/04-flytting-elever/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "4. Flytting av elever i skoleåret mellom kommuner/fylkeskommuner"
+linkTitle: "4. Flytting av elever"
+weight: 4
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Flytting av elever i skoleåret mellom kommuner og fylkeskommuner.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/05-samtykkeportal/_index.en.md
+++ b/content/use-cases/05-samtykkeportal/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "5. Consent Portal"
+linkTitle: "5. Consent Portal"
+weight: 5
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Consent portal – centralized overview of consents. Further development of FIKS consent?
+
+## Status
+
+Not started.

--- a/content/use-cases/05-samtykkeportal/_index.nb.md
+++ b/content/use-cases/05-samtykkeportal/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "5. Samtykkeportal"
+linkTitle: "5. Samtykkeportal"
+weight: 5
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Samtykkeportal – sentralisert oversikt over samtykker. Videreutvikling av FIKS samtykke?
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/06-sentralisert-datatilgang/_index.en.md
+++ b/content/use-cases/06-sentralisert-datatilgang/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "6. Centralized Access to Data Parents Need"
+linkTitle: "6. Data Access for Parents"
+weight: 6
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Centralized access to data parents need – national tests, assessments, final evaluations, etc.
+
+## Status
+
+Not started.

--- a/content/use-cases/06-sentralisert-datatilgang/_index.nb.md
+++ b/content/use-cases/06-sentralisert-datatilgang/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "6. Sentralisert tilgang til data foreldrene trenger"
+linkTitle: "6. Datatilgang for foreldre"
+weight: 6
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Sentralisert tilgang til data foreldrene trenger – nasjonale prøver, kartlegging, sluttvurdering osv.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/07-tidlig-identifisering/_index.en.md
+++ b/content/use-cases/07-tidlig-identifisering/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "7. Early Identification of At-Risk Students"
+linkTitle: "7. Early Identification"
+weight: 7
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Early identification of at-risk students and continuation of interventions and data throughout the educational pathway.
+
+## Status
+
+Not started.

--- a/content/use-cases/07-tidlig-identifisering/_index.nb.md
+++ b/content/use-cases/07-tidlig-identifisering/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "7. Tidlig identifisering av elever i faresonen"
+linkTitle: "7. Tidlig identifisering"
+weight: 7
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Tidlig identifisering av elever i faresonen og videreføring av tiltak og data gjennom opplæringsløpet.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/08-overganger-utdanningsnivaaer/_index.en.md
+++ b/content/use-cases/08-overganger-utdanningsnivaaer/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "8. Transitions Between Education Levels"
+linkTitle: "8. Education Level Transitions"
+weight: 8
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Transitions between education levels – from kindergarten to primary school, on to upper secondary and higher education. For example, exchange of student information when changing schools.
+
+## Status
+
+Not started.

--- a/content/use-cases/08-overganger-utdanningsnivaaer/_index.nb.md
+++ b/content/use-cases/08-overganger-utdanningsnivaaer/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "8. Overganger mellom utdanningsnivåer"
+linkTitle: "8. Overganger utdanningsnivåer"
+weight: 8
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Overganger mellom utdanningsnivåer – fra barnehage til grunnskole, videre til videregående og høyere utdanning. For eksempel utveksling av elevinformasjon ved skolebytte.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/09-bytte-skole/_index.en.md
+++ b/content/use-cases/09-bytte-skole/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "9. Changing School or Place of Study"
+linkTitle: "9. Changing School"
+weight: 9
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Changing school or place of study.
+
+## Status
+
+Not started.

--- a/content/use-cases/09-bytte-skole/_index.nb.md
+++ b/content/use-cases/09-bytte-skole/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "9. Bytte av skole eller studiested"
+linkTitle: "9. Bytte skole/studiested"
+weight: 9
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Bytte av skole eller studiested.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/10-overgang-kommunale-tjenester/_index.en.md
+++ b/content/use-cases/10-overgang-kommunale-tjenester/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "10. Transition to Other Municipal Services"
+linkTitle: "10. Municipal Services"
+weight: 10
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Transition to other municipal services such as child welfare or educational psychology services (PPT).
+
+## Status
+
+Not started.

--- a/content/use-cases/10-overgang-kommunale-tjenester/_index.nb.md
+++ b/content/use-cases/10-overgang-kommunale-tjenester/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "10. Overgang til andre kommunale tjenester"
+linkTitle: "10. Kommunale tjenester"
+weight: 10
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Overgang til andre kommunale tjenester som barnevern eller PPT.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/11-digital-dialog-hjem/_index.en.md
+++ b/content/use-cases/11-digital-dialog-hjem/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "11. Digital Dialogue Between Kindergarten/School and Home"
+linkTitle: "11. Digital Home Dialogue"
+weight: 11
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Digital dialogue and increased involvement between kindergarten/school and the home (parents and students).
+
+## Status
+
+Not started.

--- a/content/use-cases/11-digital-dialog-hjem/_index.nb.md
+++ b/content/use-cases/11-digital-dialog-hjem/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "11. Digital dialog mellom barnehage/skole og hjemmet"
+linkTitle: "11. Digital dialog hjem"
+weight: 11
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Digital dialog og økt involvering mellom barnehage/skole og hjemmet (foresatte og elever).
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/12-endring-utdanningsloep/_index.en.md
+++ b/content/use-cases/12-endring-utdanningsloep/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "12. Changing Educational Pathway or Study Programme"
+linkTitle: "12. Changing Pathway"
+weight: 12
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Changing educational pathway or study programme.
+
+## Status
+
+Not started.

--- a/content/use-cases/12-endring-utdanningsloep/_index.nb.md
+++ b/content/use-cases/12-endring-utdanningsloep/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "12. Endring av utdanningsløp eller studieretning"
+linkTitle: "12. Endring utdanningsløp"
+weight: 12
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Endring av utdanningsløp eller studieretning.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/13-avbrutt-utdanning/_index.en.md
+++ b/content/use-cases/13-avbrutt-utdanning/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "13. Interrupted Education (Dropout)"
+linkTitle: "13. Interrupted Education"
+weight: 13
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Interrupted education (dropout).
+
+## Status
+
+Not started.

--- a/content/use-cases/13-avbrutt-utdanning/_index.nb.md
+++ b/content/use-cases/13-avbrutt-utdanning/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "13. Avbrutt utdanning (frafall)"
+linkTitle: "13. Avbrutt utdanning"
+weight: 13
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Avbrutt utdanning (frafall).
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/14-vitnemaal-kompetansebevis/_index.en.md
+++ b/content/use-cases/14-vitnemaal-kompetansebevis/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "14. Documentation and Sharing of Diplomas and Certificates"
+linkTitle: "14. Diplomas & Certificates"
+weight: 14
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Documentation and sharing of diplomas and certificates of competence.
+
+## Status
+
+Not started.

--- a/content/use-cases/14-vitnemaal-kompetansebevis/_index.nb.md
+++ b/content/use-cases/14-vitnemaal-kompetansebevis/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "14. Dokumentasjon og deling av vitnemål og kompetansebevis"
+linkTitle: "14. Vitnemål og kompetansebevis"
+weight: 14
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Dokumentasjon og deling av vitnemål og kompetansebevis.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/15-anskaffelser-fagsystemer/_index.en.md
+++ b/content/use-cases/15-anskaffelser-fagsystemer/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "15. Procurement of Domain and Support Systems"
+linkTitle: "15. System Procurement"
+weight: 15
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Procurement of domain and support systems – increased degree of common approach and procurement of domain systems through defined frameworks, models, and architecture.
+
+## Status
+
+Not started.

--- a/content/use-cases/15-anskaffelser-fagsystemer/_index.nb.md
+++ b/content/use-cases/15-anskaffelser-fagsystemer/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "15. Anskaffelser av fag- og støttesystemer"
+linkTitle: "15. Anskaffelser fagsystemer"
+weight: 15
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Anskaffelser av fag- og støttesystemer – økt grad av felles tilnærming og anskaffelser av fagsystemer gjennom definerte rammeverk, modeller og arkitektur.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/16-ki-loesninger/_index.en.md
+++ b/content/use-cases/16-ki-loesninger/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "16. AI Solutions Based on Common Information Models"
+linkTitle: "16. AI Solutions"
+weight: 16
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+AI solutions based on structured, common information models within childhood development and education, in collaboration with other AI initiatives.
+
+## Status
+
+Not started.

--- a/content/use-cases/16-ki-loesninger/_index.nb.md
+++ b/content/use-cases/16-ki-loesninger/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "16. KI-løsninger basert på felles informasjonsmodeller"
+linkTitle: "16. KI-løsninger"
+weight: 16
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+KI-løsninger basert på strukturerte, felles informasjonsmodeller innen oppvekst og utdanning, i samarbeid med andre KI-initiativ.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/17-hendelsesdrevet-rapportering/_index.en.md
+++ b/content/use-cases/17-hendelsesdrevet-rapportering/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "17. Event-Driven and Automated Reporting"
+linkTitle: "17. Automated Reporting"
+weight: 17
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Event-driven and automated reporting with MVP on a new solution – for example reporting to Statistics Norway (SSB/KOSTRA).
+
+## Status
+
+Not started.

--- a/content/use-cases/17-hendelsesdrevet-rapportering/_index.nb.md
+++ b/content/use-cases/17-hendelsesdrevet-rapportering/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "17. Hendelsesdrevet og automatisert rapportering"
+linkTitle: "17. Automatisert rapportering"
+weight: 17
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Hendelsesdrevet og automatisert rapportering med MVP på ny løsning for dette – for eksempel rapportering til SSB/KOSTRA.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/18-saarbare-barn-skolen/_index.en.md
+++ b/content/use-cases/18-saarbare-barn-skolen/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "18. Vulnerable Children in School and Cross-Disciplinary Follow-Up"
+linkTitle: "18. Vulnerable Children"
+weight: 18
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+From UDE in the City of Oslo: Vulnerable children in school and cross-disciplinary follow-up.
+
+## Status
+
+Not started.

--- a/content/use-cases/18-saarbare-barn-skolen/_index.nb.md
+++ b/content/use-cases/18-saarbare-barn-skolen/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "18. Sårbare barn i skolen og tverrfaglig oppfølging"
+linkTitle: "18. Sårbare barn i skolen"
+weight: 18
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+Fra UDE i Oslo kommune: Sårbare barn i skolen og tverrfaglig oppfølging.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/19-statped-soknader/_index.en.md
+++ b/content/use-cases/19-statped-soknader/_index.en.md
@@ -1,0 +1,17 @@
+---
+title: "19. Statped – Applications from Educational Psychology Services"
+linkTitle: "19. Statped Applications"
+weight: 19
+---
+
+{{% notice info %}}
+This use case is under development.
+{{% /notice %}}
+
+## Description
+
+Statped – applications from the municipal educational psychology service (PPT) for assistance.
+
+## Status
+
+Not started.

--- a/content/use-cases/19-statped-soknader/_index.nb.md
+++ b/content/use-cases/19-statped-soknader/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "19. StatPed – søknader fra PP-tjenesten"
+linkTitle: "19. StatPed-søknader"
+weight: 19
+---
+
+{{% notice info %}}
+Denne brukssaken er under utarbeidelse.
+{{% /notice %}}
+
+## Beskrivelse
+
+StatPed – søknader fra PP-tjenesten i kommunen om bistand.
+
+## Status
+
+Ikke påbegynt.

--- a/content/use-cases/_index.en.md
+++ b/content/use-cases/_index.en.md
@@ -1,6 +1,9 @@
 ---
 title: "Use Cases"
-draft: false
+linkTitle: "Use Cases"
+weight: 30
 ---
 
-Overview of use cases.
+Overview of identified use cases for collaboration within childhood development and education.
+
+Select a use case below for more information.

--- a/content/use-cases/_index.nb.md
+++ b/content/use-cases/_index.nb.md
@@ -1,6 +1,9 @@
 ---
-title: "Use Cases"
-draft: false
+title: "Brukssaker"
+linkTitle: "Brukssaker"
+weight: 30
 ---
 
-Oversikt over use cases.
+Oversikt over identifiserte brukssaker for samhandling innen oppvekst og utdanning.
+
+Velg en brukssak nedenfor for mer informasjon.


### PR DESCRIPTION
Oppretter undersider for alle identifiserte brukssaker innen oppvekst og utdanning, med _index.nb.md og _index.en.md for hver brukssak. Oppdaterer også overordnet use-cases index.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx