### PR TITLE
Legg til innholdsfortegnelse (TOC) på høyre side av sider

### DIFF
--- a/content/use-cases/01-resultater-vgo/_index.en.md
+++ b/content/use-cases/01-resultater-vgo/_index.en.md
@@ -2,6 +2,7 @@
 title: "1. Making Results from Upper Secondary Education Accessible"
 linkTitle: "1. Results from Upper Secondary"
 weight: 1
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/01-resultater-vgo/_index.nb.md
+++ b/content/use-cases/01-resultater-vgo/_index.nb.md
@@ -2,6 +2,7 @@
 title: "1. Tilgjengeliggjøre resultater fra videregående opplæring"
 linkTitle: "1. Resultater fra VGO"
 weight: 1
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/02-overgang-grunnskole-vgo/_index.en.md
+++ b/content/use-cases/02-overgang-grunnskole-vgo/_index.en.md
@@ -2,6 +2,7 @@
 title: "2. Seamless Transition from Primary to Upper Secondary Education"
 linkTitle: "2. Primary to Upper Secondary"
 weight: 2
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/02-overgang-grunnskole-vgo/_index.nb.md
+++ b/content/use-cases/02-overgang-grunnskole-vgo/_index.nb.md
@@ -2,6 +2,7 @@
 title: "2. Sømløs overgang fra grunnskole til videregående opplæring"
 linkTitle: "2. Overgang grunnskole–VGO"
 weight: 2
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/03-id-haandtering-flyktninger/_index.en.md
+++ b/content/use-cases/03-id-haandtering-flyktninger/_index.en.md
@@ -2,6 +2,7 @@
 title: "3. ID Management for Refugees and Use of D-numbers"
 linkTitle: "3. Refugee ID Management"
 weight: 3
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/03-id-haandtering-flyktninger/_index.nb.md
+++ b/content/use-cases/03-id-haandtering-flyktninger/_index.nb.md
@@ -2,6 +2,7 @@
 title: "3. ID-håndtering av flyktninger og bruk av D-nummer"
 linkTitle: "3. ID-håndtering flyktninger"
 weight: 3
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/04-flytting-elever/_index.en.md
+++ b/content/use-cases/04-flytting-elever/_index.en.md
@@ -2,6 +2,7 @@
 title: "4. Student Relocation Between Municipalities During the School Year"
 linkTitle: "4. Student Relocation"
 weight: 4
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/04-flytting-elever/_index.nb.md
+++ b/content/use-cases/04-flytting-elever/_index.nb.md
@@ -2,6 +2,7 @@
 title: "4. Flytting av elever i skoleåret mellom kommuner/fylkeskommuner"
 linkTitle: "4. Flytting av elever"
 weight: 4
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/05-samtykkeportal/_index.en.md
+++ b/content/use-cases/05-samtykkeportal/_index.en.md
@@ -2,6 +2,7 @@
 title: "5. Consent Portal"
 linkTitle: "5. Consent Portal"
 weight: 5
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/05-samtykkeportal/_index.nb.md
+++ b/content/use-cases/05-samtykkeportal/_index.nb.md
@@ -2,6 +2,7 @@
 title: "5. Samtykkeportal"
 linkTitle: "5. Samtykkeportal"
 weight: 5
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/06-sentralisert-datatilgang/_index.en.md
+++ b/content/use-cases/06-sentralisert-datatilgang/_index.en.md
@@ -2,6 +2,7 @@
 title: "6. Centralized Access to Data Parents Need"
 linkTitle: "6. Data Access for Parents"
 weight: 6
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/06-sentralisert-datatilgang/_index.nb.md
+++ b/content/use-cases/06-sentralisert-datatilgang/_index.nb.md
@@ -2,6 +2,7 @@
 title: "6. Sentralisert tilgang til data foreldrene trenger"
 linkTitle: "6. Datatilgang for foreldre"
 weight: 6
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/07-tidlig-identifisering/_index.en.md
+++ b/content/use-cases/07-tidlig-identifisering/_index.en.md
@@ -2,6 +2,7 @@
 title: "7. Early Identification of At-Risk Students"
 linkTitle: "7. Early Identification"
 weight: 7
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/07-tidlig-identifisering/_index.nb.md
+++ b/content/use-cases/07-tidlig-identifisering/_index.nb.md
@@ -2,6 +2,7 @@
 title: "7. Tidlig identifisering av elever i faresonen"
 linkTitle: "7. Tidlig identifisering"
 weight: 7
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/08-overganger-utdanningsnivaaer/_index.en.md
+++ b/content/use-cases/08-overganger-utdanningsnivaaer/_index.en.md
@@ -2,6 +2,7 @@
 title: "8. Transitions Between Education Levels"
 linkTitle: "8. Education Level Transitions"
 weight: 8
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/08-overganger-utdanningsnivaaer/_index.nb.md
+++ b/content/use-cases/08-overganger-utdanningsnivaaer/_index.nb.md
@@ -2,6 +2,7 @@
 title: "8. Overganger mellom utdanningsnivåer"
 linkTitle: "8. Overganger utdanningsnivåer"
 weight: 8
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/09-bytte-skole/_index.en.md
+++ b/content/use-cases/09-bytte-skole/_index.en.md
@@ -2,6 +2,7 @@
 title: "9. Changing School or Place of Study"
 linkTitle: "9. Changing School"
 weight: 9
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/09-bytte-skole/_index.nb.md
+++ b/content/use-cases/09-bytte-skole/_index.nb.md
@@ -2,6 +2,7 @@
 title: "9. Bytte av skole eller studiested"
 linkTitle: "9. Bytte skole/studiested"
 weight: 9
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/10-overgang-kommunale-tjenester/_index.en.md
+++ b/content/use-cases/10-overgang-kommunale-tjenester/_index.en.md
@@ -2,6 +2,7 @@
 title: "10. Transition to Other Municipal Services"
 linkTitle: "10. Municipal Services"
 weight: 10
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/10-overgang-kommunale-tjenester/_index.nb.md
+++ b/content/use-cases/10-overgang-kommunale-tjenester/_index.nb.md
@@ -2,6 +2,7 @@
 title: "10. Overgang til andre kommunale tjenester"
 linkTitle: "10. Kommunale tjenester"
 weight: 10
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/11-digital-dialog-hjem/_index.en.md
+++ b/content/use-cases/11-digital-dialog-hjem/_index.en.md
@@ -2,6 +2,7 @@
 title: "11. Digital Dialogue Between Kindergarten/School and Home"
 linkTitle: "11. Digital Home Dialogue"
 weight: 11
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/11-digital-dialog-hjem/_index.nb.md
+++ b/content/use-cases/11-digital-dialog-hjem/_index.nb.md
@@ -2,6 +2,7 @@
 title: "11. Digital dialog mellom barnehage/skole og hjemmet"
 linkTitle: "11. Digital dialog hjem"
 weight: 11
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/12-endring-utdanningsloep/_index.en.md
+++ b/content/use-cases/12-endring-utdanningsloep/_index.en.md
@@ -2,6 +2,7 @@
 title: "12. Changing Educational Pathway or Study Programme"
 linkTitle: "12. Changing Pathway"
 weight: 12
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/12-endring-utdanningsloep/_index.nb.md
+++ b/content/use-cases/12-endring-utdanningsloep/_index.nb.md
@@ -2,6 +2,7 @@
 title: "12. Endring av utdanningsløp eller studieretning"
 linkTitle: "12. Endring utdanningsløp"
 weight: 12
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/13-avbrutt-utdanning/_index.en.md
+++ b/content/use-cases/13-avbrutt-utdanning/_index.en.md
@@ -2,6 +2,7 @@
 title: "13. Interrupted Education (Dropout)"
 linkTitle: "13. Interrupted Education"
 weight: 13
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/13-avbrutt-utdanning/_index.nb.md
+++ b/content/use-cases/13-avbrutt-utdanning/_index.nb.md
@@ -2,6 +2,7 @@
 title: "13. Avbrutt utdanning (frafall)"
 linkTitle: "13. Avbrutt utdanning"
 weight: 13
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/14-vitnemaal-kompetansebevis/_index.en.md
+++ b/content/use-cases/14-vitnemaal-kompetansebevis/_index.en.md
@@ -2,6 +2,7 @@
 title: "14. Documentation and Sharing of Diplomas and Certificates"
 linkTitle: "14. Diplomas & Certificates"
 weight: 14
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/14-vitnemaal-kompetansebevis/_index.nb.md
+++ b/content/use-cases/14-vitnemaal-kompetansebevis/_index.nb.md
@@ -2,6 +2,7 @@
 title: "14. Dokumentasjon og deling av vitnemål og kompetansebevis"
 linkTitle: "14. Vitnemål og kompetansebevis"
 weight: 14
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/15-anskaffelser-fagsystemer/_index.en.md
+++ b/content/use-cases/15-anskaffelser-fagsystemer/_index.en.md
@@ -2,6 +2,7 @@
 title: "15. Procurement of Domain and Support Systems"
 linkTitle: "15. System Procurement"
 weight: 15
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/15-anskaffelser-fagsystemer/_index.nb.md
+++ b/content/use-cases/15-anskaffelser-fagsystemer/_index.nb.md
@@ -2,6 +2,7 @@
 title: "15. Anskaffelser av fag- og støttesystemer"
 linkTitle: "15. Anskaffelser fagsystemer"
 weight: 15
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/16-ki-loesninger/_index.en.md
+++ b/content/use-cases/16-ki-loesninger/_index.en.md
@@ -2,6 +2,7 @@
 title: "16. AI Solutions Based on Common Information Models"
 linkTitle: "16. AI Solutions"
 weight: 16
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/16-ki-loesninger/_index.nb.md
+++ b/content/use-cases/16-ki-loesninger/_index.nb.md
@@ -2,6 +2,7 @@
 title: "16. KI-løsninger basert på felles informasjonsmodeller"
 linkTitle: "16. KI-løsninger"
 weight: 16
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/17-hendelsesdrevet-rapportering/_index.en.md
+++ b/content/use-cases/17-hendelsesdrevet-rapportering/_index.en.md
@@ -2,6 +2,7 @@
 title: "17. Event-Driven and Automated Reporting"
 linkTitle: "17. Automated Reporting"
 weight: 17
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/17-hendelsesdrevet-rapportering/_index.nb.md
+++ b/content/use-cases/17-hendelsesdrevet-rapportering/_index.nb.md
@@ -2,6 +2,7 @@
 title: "17. Hendelsesdrevet og automatisert rapportering"
 linkTitle: "17. Automatisert rapportering"
 weight: 17
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/18-saarbare-barn-skolen/_index.en.md
+++ b/content/use-cases/18-saarbare-barn-skolen/_index.en.md
@@ -2,6 +2,7 @@
 title: "18. Vulnerable Children in School and Cross-Disciplinary Follow-Up"
 linkTitle: "18. Vulnerable Children"
 weight: 18
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/18-saarbare-barn-skolen/_index.nb.md
+++ b/content/use-cases/18-saarbare-barn-skolen/_index.nb.md
@@ -2,6 +2,7 @@
 title: "18. Sårbare barn i skolen og tverrfaglig oppfølging"
 linkTitle: "18. Sårbare barn i skolen"
 weight: 18
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/19-statped-soknader/_index.en.md
+++ b/content/use-cases/19-statped-soknader/_index.en.md
@@ -2,6 +2,7 @@
 title: "19. Statped – Applications from Educational Psychology Services"
 linkTitle: "19. Statped Applications"
 weight: 19
+toc: true
 ---
 
 {{% notice info %}}

--- a/content/use-cases/19-statped-soknader/_index.nb.md
+++ b/content/use-cases/19-statped-soknader/_index.nb.md
@@ -2,6 +2,7 @@
 title: "19. StatPed – søknader fra PP-tjenesten"
 linkTitle: "19. StatPed-søknader"
 weight: 19
+toc: true
 ---
 
 {{% notice info %}}

--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -61,4 +61,52 @@
     height: 1.2em;
     vertical-align: bottom;
   }
+
+  /* Right-side Table of Contents */
+  #page-toc {
+    position: sticky;
+    top: 20px;
+    float: right;
+    width: 220px;
+    margin-left: 30px;
+    margin-right: -250px;
+    padding: 12px 16px;
+    font-size: 13px;
+    border-left: 2px solid #e0e0e0;
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+  #page-toc h3 {
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 0;
+    margin-bottom: 8px;
+    color: #333;
+  }
+  #page-toc #TableOfContents {
+    font-size: 13px;
+    padding: 0;
+  }
+  #page-toc #TableOfContents ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+  #page-toc #TableOfContents li {
+    margin-bottom: 4px;
+    padding-left: 0;
+  }
+  #page-toc #TableOfContents a {
+    color: #555;
+    text-decoration: none;
+  }
+  #page-toc #TableOfContents a:hover {
+    color: #17c;
+    text-decoration: underline;
+  }
+  @media (max-width: 1280px) {
+    #page-toc {
+      display: none;
+    }
+  }
 </style>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -96,9 +96,11 @@
             {{end}}
           {{end}}
 
-          {{ if and (gt .WordCount 100 ) (.Params.toc) }}
-            <h2>På denne siden:</h2>
+          {{ if .Params.toc }}
+            <aside id="page-toc">
+              <h3>{{ cond (eq .Page.Language.Lang "nb") "På denne siden" "On this page" }}</h3>
               {{ .TableOfContents }}
+            </aside>
           {{ end }}
 
 {{define "breadcrumb"}}


### PR DESCRIPTION
Implementerer sticky TOC-sidebar til høyre for sideinnhold, tilsvarende Altinn docs. Aktiveres via toc: true i front matter. Skjules på skjermer smalere enn 1280px. Fjerner 100-ords-kravet slik at TOC vises også på korte sider.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx