### PR TITLE
Endre TOC til ekte 3-kolonne flex-layout

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -62,18 +62,27 @@
     vertical-align: bottom;
   }
 
+  /* 3-column layout: left sidebar | content | right TOC */
+  .body-toc-wrapper {
+    display: flex;
+    align-items: flex-start;
+  }
+  .body-toc-wrapper #body {
+    flex: 1;
+    min-width: 0;
+  }
+
   /* Right-side Table of Contents */
   #page-toc {
     position: sticky;
     top: 20px;
-    float: right;
     width: 220px;
-    margin-left: 30px;
-    margin-right: -250px;
+    flex-shrink: 0;
     padding: 12px 16px;
+    margin-left: 20px;
     font-size: 13px;
     border-left: 2px solid #e0e0e0;
-    max-height: 80vh;
+    max-height: 85vh;
     overflow-y: auto;
   }
   #page-toc h3 {
@@ -104,7 +113,10 @@
     color: #17c;
     text-decoration: underline;
   }
-  @media (max-width: 1280px) {
+  @media (max-width: 1100px) {
+    .body-toc-wrapper {
+      display: block;
+    }
     #page-toc {
       display: none;
     }

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -63,6 +63,13 @@
 
         </section>
 
+          {{ if .Params.toc }}
+            <aside id="page-toc">
+              <h3>{{ cond (eq .Page.Language.Lang "nb") "På denne siden" "On this page" }}</h3>
+              {{ .TableOfContents }}
+            </aside>
+          {{ end }}
+        </div><!-- End body-toc-wrapper -->
 
         </div> <!-- End col-sm-12 -->
       </div> <!-- End row -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -50,6 +50,7 @@
             <div class="col-sm-12">
 
     {{ partial "menu.html" . }}
+        <div class="body-toc-wrapper">
         <section id="body">
           <div id="content" class="adocs-content js-moveChildrenTo">
         <div id="overlay"></div>
@@ -95,13 +96,6 @@
               <p class="a-leadText" id="leadText">{{.Description}}</p>
             {{end}}
           {{end}}
-
-          {{ if .Params.toc }}
-            <aside id="page-toc">
-              <h3>{{ cond (eq .Page.Language.Lang "nb") "På denne siden" "On this page" }}</h3>
-              {{ .TableOfContents }}
-            </aside>
-          {{ end }}
 
 {{define "breadcrumb"}}
 {{ if .page.Parent}}


### PR DESCRIPTION
Flytt TOC fra inni innholdsområdet til egen kolonne ved siden av. Erstatter float/negativ-margin-hack med flexbox-grid:
- .body-toc-wrapper som flex-container rundt #body + #page-toc
- #body tar gjenværende plass (flex: 1)
- #page-toc er fast 220px kolonne til høyre
- Kollapser til 1-kolonne under 1100px bredde

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx