### PR TITLE
Flytt søkeboks fra sidebar til header, legg til gap mellom kolonner

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -62,6 +62,37 @@
     vertical-align: bottom;
   }
 
+  /* Header actions: search + language switcher side by side */
+  .a-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  /* Search box in header */
+  .header-search {
+    border-color: rgba(255,255,255,0.5) !important;
+    background: rgba(255,255,255,0.1) !important;
+    width: 220px;
+    height: 32px !important;
+  }
+  .header-search label {
+    color: rgba(255,255,255,0.7);
+  }
+  .header-search input {
+    color: #fff;
+    height: 26px !important;
+  }
+  .header-search input::placeholder {
+    color: rgba(255,255,255,0.5);
+  }
+  .header-search span {
+    color: rgba(255,255,255,0.5);
+  }
+  .header-search span:hover {
+    color: #fff;
+  }
+
   /* Wider container to use more screen space */
   @media (min-width: 1200px) {
     .container {
@@ -116,6 +147,7 @@
       min-width: 0;
       display: flex;
       align-items: flex-start;
+      margin-left: 16px;
     }
     .body-toc-wrapper #body {
       flex: 1;

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -6,9 +6,6 @@
 {{ $showvisitedlinks := .Site.Params.showVisitedLinks }}
 <div class="highlightable">
   <div id="header-wrapper">
-    {{if not .Site.Params.noSearch}}
-        {{ partial "search.html" . }}
-    {{end}}
   </div>
 
 

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,0 +1,11 @@
+<div class="searchbox header-search">
+    <label for="search-by"><i class="fa fa-search"></i></label>
+    <input data-search-input id="search-by" type="text" placeholder="{{T "Search-placeholder"}}">
+    <span data-search-clear=""><i class="fa fa-close"></i></span>
+</div>
+<script src="{{"js/lunr.min.js" | relURL}}"></script>
+<script src="{{"js/horsey.js" | relURL}}"></script>
+<script>
+    var baseurl = "{{.Site.BaseURL}}";
+</script>
+<script src="{{"js/search.js" | relURL}}"></script>

--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -14,7 +14,12 @@
             <img src="{{ "images/SAMT-BU-logo.png" | relURL }}" alt="SAMT-BU logo" class="a-logo a-modal-top-logo" style="height: 40px; width: auto; margin-right: 10px; filter: brightness(0) invert(1);">
             <span style="color: #fff; font-size: 1.8rem; font-weight: bold;">{{ .Site.Title }}</span>
           </a>
-          {{ partial "lang-switcher.html" . }}
+          <div class="a-header-actions">
+            {{if not .Site.Params.noSearch}}
+              {{ partial "search.html" . }}
+            {{end}}
+            {{ partial "lang-switcher.html" . }}
+          </div>
         </nav>
       </div>
     </div>


### PR DESCRIPTION
- Fjern søkeboks fra sidebar (menu.html)
- Legg søkeboks i header til venstre for språkvelger (topbar.html)
- Ny lokal search.html med header-search klasse
- Style søkeboks for mørk header-bakgrunn (hvit tekst, gjennomsiktig bakgrunn)
- Legg til 16px margin-left på body-toc-wrapper for luft mellom kol 1 og 2

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx