### PR TITLE
Fyll inn use case #2 med casebeskrivelse, endre Brukssaker til Use cases

### DIFF
--- a/content/use-cases/02-overgang-grunnskole-vgo/_index.nb.md
+++ b/content/use-cases/02-overgang-grunnskole-vgo/_index.nb.md
@@ -5,14 +5,112 @@ weight: 2
 toc: true
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
+## Kort beskrivelse
 
-## Beskrivelse
+Caset tar for seg overgangen fra ungdomsskole til videregående opplæring -- en av de mest sentrale overgangene i barn og unges livsløp. Overgangen innebærer både et skifte i skolehverdag og et formelt ansvarsskifte fra kommune til fylkeskommune, og berører mange aktører, tjenester og systemer.
 
-Sømløs overgang fra grunnskole til videregående opplæring.
+For ungdom er dette en fase preget av forventninger, valg og økt ansvar for egen hverdag. For foresatte handler det om trygghet for at barnet får riktig oppfølging. For ansatte i skole og støtteapparat handler det om å gi et godt tilbud, ofte under tidspress og med begrenset oversikt.
 
-## Status
+I denne overgangen er det behov for at relevant informasjon følger eleven på en trygg, presis og forståelig måte -- uten at eleven eller foresatte selv må fungere som informasjonsbærer mellom aktører. Caset belyser hvordan dagens praksis og systemer i begrenset grad støtter dette behovet.
 
-Ikke påbegynt.
+### Hvem har spilt inn dette caset?
+
+Prosjektgruppen i SAMT-BU, basert på felles innsikt fra kommuner, fylkeskommuner og statlige aktører innen utdannings- og oppvekstsektoren.
+
+## Problemet i dag
+
+I dag opplever mange at overgangen mellom ungdomsskole og videregående ikke er godt nok støttet av sammenhengende informasjonsflyt. Viktig kunnskap om elevens skoleløp, behov for tilrettelegging, tidligere tiltak eller oppfølging blir ofte ikke tilgjengelig for riktig aktør til riktig tid.
+
+Dette fører til at informasjon må gjeninnhentes eller vurderes på nytt, og at oppfølging kan bli forsinket eller mangelfull.
+
+### Hvor oppstår brudd i informasjonsflyt eller ansvar?
+
+Brudd oppstår særlig:
+
+- når ansvaret flyttes fra kommune til fylkeskommune
+- når ulike tjenester og forvaltningsnivåer har ulike forståelser av begreper, roller og ansvar
+- når fagsystemer og arbeidsprosesser ikke er tilpasset samhandling på tvers
+- når det er usikkerhet rundt hva som kan, bør og skal deles av informasjon
+
+## Aktører
+
+### Sluttbrukere
+
+- Ungdom som går fra ungdomsskole til videregående opplæring
+- Foresatte
+
+### Ansatte i tjenestene
+
+- Lærere, rådgivere og skoleledelse i ungdomsskole og videregående skole
+- Støttetjenester som PPT og oppfølgingstjenesten (OT)
+
+### Fagsystemleverandører
+
+- Leverandører av skoleadministrative systemer og tilgrensende støttesystemer i grunnskole og videregående opplæring
+
+### Premissgivere
+
+#### Direktorater (faglige og operasjonelle premissgivere)
+
+- **Utdanningsdirektoratet** -- Fagdirektorat for grunnopplæringen. Setter føringer for læreplaner, vurdering, begreper, rapportering og bruk av utdanningsdata.
+- **Digitaliseringsdirektoratet** -- Tverrsektoriell premissgiver for digital samhandling, datadeling, arkitektur og sammenhengende tjenester.
+- **Bufdir** -- Premissgiver for helhetlig oppfølging av barn og unge, særlig i grenseflater mot barnevern og familie.
+- **Helsedirektoratet** (der relevant) -- Premissgiver for regelverk og praksis knyttet til helse og samhandling rundt barn og unge.
+
+#### Departementer (politiske og styringsmessige premissgivere)
+
+- **Kunnskapsdepartementet** -- Overordnet ansvar for utdanningssektoren og styringssignaler til underliggende etater.
+- **Digitaliserings- og forvaltningsdepartementet** -- Overordnet ansvar for digitalisering, datadeling og tverrsektorielle initiativ.
+- **Barne- og familiedepartementet** (der relevant) -- Premissgiver for politikk knyttet til barn, unge og familier.
+
+### Tjenesteleverandører
+
+- **Kommuner** -- Ansvar for grunnskole, PPT og flere støttefunksjoner. Nærmest brukerne i praksis.
+- **Fylkeskommuner** -- Ansvar for videregående opplæring, oppfølgingstjeneste og overgang videre i utdanningsløpet.
+
+### Samordnende og støttende aktører
+
+- **KS** -- Interesseorganisasjon for kommunesektoren og viktig brobygger mellom stat og kommune.
+- **KS Digital** -- Operativ aktør for felles kommunale digitale løsninger og samhandling.
+- **Sikt** -- Leverer og forvalter fellestjenester i utdanningssektoren, særlig i grenseflater mot videre utdanning.
+- **SSB** -- Bruker utdanningsdata til statistikk, analyse og innsikt.
+
+## Konsekvenser av dagens situasjon
+
+### For sluttbrukere (ungdom og foresatte)
+
+- Utrygghet i en allerede krevende overgang
+- Behov for å forklare situasjon og behov flere ganger
+- Risiko for forsinket eller mangelfull oppfølging
+
+### For ansatte i tjenestene
+
+- Merarbeid knyttet til manuell koordinering
+- Manglende helhetsoversikt og usikkerhet i beslutninger
+- Risiko for at tiltak ikke videreføres eller kommer for sent
+
+### For organisasjonene
+
+- Ineffektiv bruk av tid og ressurser
+- Økt risiko for feil, forsinkelser og frafall
+
+### På systemnivå
+
+Konsekvensene merkes både på individnivå og systemnivå. Elever kan oppleve brudd i oppfølging, ansatte bruker tid på å kompensere for manglende sammenheng, og organisasjonene får redusert effekt av tiltak som allerede er satt i gang. Utfordringene handler i liten grad om manglende innsats eller vilje, men om strukturelle barrierer som fragmenterte systemer, uklare grensesnitt og manglende felles rammer for informasjonsdeling.
+
+## Ønskesituasjon
+
+I en ønsket situasjon opplever ungdom og foresatte en helhetlig overgang der relevant informasjon er tilgjengelig for riktige aktører til rett tid. Ansatte har bedre oversikt og beslutningsgrunnlag, og kan raskere gi riktig oppfølging. Samhandlingen mellom kommune, fylkeskommune og stat er tydeligere, og informasjon flyter på en måte som støtter sammenhengende tjenester -- uten unødvendig belastning på brukerne.
+
+## Innsiktsarbeid
+
+Caset bygger på tidligere innsikt fra arbeid med sammenhengende tjenester for barn og unge, inkludert erfaringer fra kommuner, fylkeskommuner og statlige aktører knyttet til overganger i utdanningsløpet.
+
+## Berørte prosjektmål
+
+Caset berører særlig følgende målsetninger:
+
+- Enklere og mer sammenhengende brukerreiser for elever, foresatte og ansatte gjennom utdanningsløpet
+- Bedre samhandling og informasjonsflyt på tvers av forvaltningsnivå og sektorer
+- Et bedre utgangspunkt for utvikling av felles informasjonsmodeller og gjenbrukbare løsninger
+- Læring og erfaringer som kan overføres til andre overganger i barn og unges livsløp og til andre sektorer

--- a/content/use-cases/_index.nb.md
+++ b/content/use-cases/_index.nb.md
@@ -1,6 +1,6 @@
 ---
-title: "Brukssaker"
-linkTitle: "Brukssaker"
+title: "Use cases"
+linkTitle: "Use cases"
 weight: 30
 ---
 


### PR DESCRIPTION
Legger inn fullstendig innhold for use case #2 (sømløs overgang grunnskole-VGO) basert på casebeskrivelse fra prosjektgruppen. Endrer navigasjonsoverskrift fra "Brukssaker" til "Use cases".

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx