### PR TITLE
Legg til 'Sist endret' dato og 'Endre denne siden i Github'-lenke

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -19,5 +19,7 @@ defaultContentLanguageInSubdir = false
     title = "SAMT-BU Documentation"
     weight = 2
 
+enableGitInfo = true
+
 [params]
-  # tilpasses senere
+  editURL = "https://github.com/SAMT-BU/samt-bu-docs/edit/main/content/"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,2 @@
+[Last-modified]
+other = "Last modified"

--- a/i18n/nb.toml
+++ b/i18n/nb.toml
@@ -1,0 +1,2 @@
+[Last-modified]
+other = "Sist endret"

--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -210,6 +210,31 @@
     border-bottom: 1px solid #000 !important;
     padding-bottom: 1px;
   }
+  /* Page meta info: "Sist endret" + "Endre denne siden" */
+  .page-meta-info {
+    text-align: right;
+    font-size: 13px;
+    color: #666;
+    margin-bottom: 12px;
+  }
+
+  /* Edit-on-GitHub link at bottom */
+  #top-github-link {
+    text-align: right;
+    font-size: 13px;
+    margin-top: 24px;
+    padding-top: 12px;
+    border-top: 1px solid #e0e0e0;
+  }
+  #top-github-link a {
+    color: #1EAEF7;
+    text-decoration: none;
+    border-bottom: none !important;
+  }
+  #top-github-link a:hover {
+    border-bottom: 1px solid #1EAEF7 !important;
+  }
+
   @media (max-width: 767px) {
     .body-toc-wrapper {
       display: block;

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -95,6 +95,13 @@
               </h1>
               <p class="a-leadText" id="leadText">{{.Description}}</p>
             {{end}}
+            {{ if not .Lastmod.IsZero }}
+              <div class="page-meta-info">
+                <span class="last-modified">
+                  {{T "Last-modified"}} {{ .Lastmod.Format "02.01.2006" }}
+                </span>
+              </div>
+            {{ end }}
           {{end}}
 
 {{define "breadcrumb"}}


### PR DESCRIPTION
Aktiverer enableGitInfo for å hente siste endringsdato fra git, og setter editURL slik at temaets innebygde edit-lenke aktiveres. Legger til "Sist endret DD.MM.YYYY" høyrejustert under tittelen, med i18n-støtte for bokmål og engelsk.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx