### PR TITLE
Flytt 'Sist endret' til øverst til høyre ved breadcrumbs

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -210,12 +210,18 @@
     border-bottom: 1px solid #000 !important;
     padding-bottom: 1px;
   }
-  /* Page meta info: "Sist endret" + "Endre denne siden" */
-  .page-meta-info {
-    text-align: right;
+  /* Top bar: breadcrumbs left, "Sist endret" right */
+  #top-bar {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .page-meta-lastmod {
     font-size: 13px;
     color: #666;
-    margin-bottom: 12px;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 
   /* Edit-on-GitHub link at bottom */

--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-12">
                 <nav class="a-footerExtraNav">
-                    SAMT-BU {{ now.Format "2006-01-02 15:04:05" }}
+                    SAMT-BU
                 </nav>
             </div>
         </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,7 +57,7 @@
         <div class="a-text">
         {{if not .IsHome}}
           <div id="top-bar">
-            
+
 
             <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
                 <span id="sidebar-toggle-span" class="adocs-sidebarToggle">
@@ -73,6 +73,11 @@
                   {{ template "breadcrumb" dict "page" . "value" .LinkTitle }}
                 </span>
             </div>
+            {{ if not .Lastmod.IsZero }}
+              <div class="page-meta-lastmod">
+                {{T "Last-modified"}}: {{ .Lastmod.Format "2006-01-02 15:04" }}
+              </div>
+            {{ end }}
           </div>
         {{end}}
         {{if .Params.tags }}
@@ -95,13 +100,6 @@
               </h1>
               <p class="a-leadText" id="leadText">{{.Description}}</p>
             {{end}}
-            {{ if not .Lastmod.IsZero }}
-              <div class="page-meta-info">
-                <span class="last-modified">
-                  {{T "Last-modified"}} {{ .Lastmod.Format "02.01.2006" }}
-                </span>
-              </div>
-            {{ end }}
           {{end}}
 
 {{define "breadcrumb"}}


### PR DESCRIPTION
- Flytter 'Sist endret: yyyy-mm-dd hh:mm' fra under tittelen til top-bar ved siden av breadcrumbs (venstre: breadcrumbs, høyre: dato)
- Fjerner byggedato-stempel fra footer (SAMT-BU dato klokkeslett)
- Gjør #top-bar til flexbox for riktig layout

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx