### PR TITLE
Flytt 'Sist endret' til rett under overskrift/ingress

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -210,18 +210,14 @@
     border-bottom: 1px solid #000 !important;
     padding-bottom: 1px;
   }
-  /* Top bar: breadcrumbs left, "Sist endret" right */
-  #top-bar {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 12px;
-  }
-  .page-meta-lastmod {
+  /* Page metadata row below title (extensible with status etc.) */
+  .page-meta {
     font-size: 13px;
     color: #666;
-    white-space: nowrap;
-    flex-shrink: 0;
+    margin-bottom: 16px;
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
   }
 
   /* Edit-on-GitHub link at bottom */

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -73,11 +73,6 @@
                   {{ template "breadcrumb" dict "page" . "value" .LinkTitle }}
                 </span>
             </div>
-            {{ if not .Lastmod.IsZero }}
-              <div class="page-meta-lastmod">
-                {{T "Last-modified"}}: {{ .Lastmod.Format "2006-01-02 15:04" }}
-              </div>
-            {{ end }}
           </div>
         {{end}}
         {{if .Params.tags }}
@@ -100,6 +95,11 @@
               </h1>
               <p class="a-leadText" id="leadText">{{.Description}}</p>
             {{end}}
+            <div class="page-meta">
+              {{ if not .Lastmod.IsZero }}
+                <span class="page-meta-lastmod">{{T "Last-modified"}}: {{ .Lastmod.Format "2006-01-02 15:04" }}</span>
+              {{ end }}
+            </div>
           {{end}}
 
 {{define "breadcrumb"}}


### PR DESCRIPTION
- Plasserer 'Sist endret: yyyy-mm-dd hh:mm' i en egen .page-meta div rett under tittel og beskrivelse, der den er godt synlig
- .page-meta er en flexbox-rad som enkelt kan utvides med flere metadata-felt (f.eks. status) i fremtiden
- Fjerner top-bar flex-endringer som ikke fungerte visuelt

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx