### PR TITLE
Fiks enableGitInfo: flytt til rot-nivå i TOML-konfig

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,7 @@ title = "SAMT-BU Dokumentasjon"
 theme = "hugo-theme-altinn"
 defaultContentLanguage = "nb"
 defaultContentLanguageInSubdir = false
+enableGitInfo = true
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]
@@ -18,8 +19,6 @@ defaultContentLanguageInSubdir = false
     languageName = "English"
     title = "SAMT-BU Documentation"
     weight = 2
-
-enableGitInfo = true
 
 [params]
   editURL = "https://github.com/SAMT-BU/samt-bu-docs/edit/main/content/"


### PR DESCRIPTION
enableGitInfo var plassert etter [languages.en]-seksjonen i hugo.toml, slik at TOML-parseren tolket den som en del av languages.en i stedet for en rot-innstilling. Flytter den til toppen sammen med andre rot-innstillinger slik at .Lastmod faktisk fylles med git-dato.

Fjerner også debug-output fra header-templaten.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx