### PR TITLE
Legg til Tema-dropdown i header for komponent-navigasjon

### DIFF
--- a/layouts/partials/custom-footer.html
+++ b/layouts/partials/custom-footer.html
@@ -6,6 +6,23 @@ $(document).ready(function() {
   toggle.on('click', function(e) {
     e.stopPropagation();
     menu.toggleClass('open');
+    $('#tema-menu').removeClass('open');
+  });
+  $(document).on('click', function() {
+    menu.removeClass('open');
+  });
+});
+</script>
+
+<!-- Tema switcher toggle -->
+<script>
+$(document).ready(function() {
+  var toggle = $('#tema-toggle');
+  var menu = $('#tema-menu');
+  toggle.on('click', function(e) {
+    e.stopPropagation();
+    menu.toggleClass('open');
+    $('#lang-menu').removeClass('open');
   });
   $(document).on('click', function() {
     menu.removeClass('open');

--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -62,6 +62,83 @@
     vertical-align: bottom;
   }
 
+  /* Tema switcher (component selector) */
+  .tema-switcher {
+    position: relative;
+  }
+  .tema-switcher-toggle {
+    color: #fff;
+    cursor: pointer;
+    padding: 8px 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+    border: 1px solid rgba(255,255,255,0.3);
+    border-radius: 4px;
+  }
+  .tema-switcher-toggle:hover {
+    background: rgba(255,255,255,0.1);
+  }
+  .tema-label {
+    opacity: 0.7;
+  }
+  .tema-active {
+    font-weight: bold;
+  }
+  .tema-switcher-menu {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 100%;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    list-style: none;
+    margin: 4px 0 0 0;
+    padding: 4px 0;
+    min-width: 180px;
+    z-index: 1000;
+  }
+  .tema-switcher-menu.open {
+    display: block;
+  }
+  .tema-switcher-menu li a {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    color: #333;
+    text-decoration: none;
+    font-size: 14px;
+    white-space: nowrap;
+    border-bottom: none !important;
+  }
+  .tema-switcher-menu li a:hover {
+    background: #f0f0f0;
+  }
+  .tema-switcher-menu li.active a {
+    font-weight: bold;
+  }
+  .tema-switcher-menu li a .fa-check {
+    color: #17c;
+    margin-left: auto;
+  }
+  .tema-switcher-menu li.disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .tema-disabled-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    color: #999;
+    font-size: 14px;
+    white-space: nowrap;
+  }
+
   /* Header actions: search + language switcher side by side */
   .a-header-actions {
     display: flex;

--- a/layouts/partials/tema-switcher.html
+++ b/layouts/partials/tema-switcher.html
@@ -1,0 +1,47 @@
+{{/* Determine which tema is active based on the current URL */}}
+{{ $activeTema := "" }}
+{{ $url := .RelPermalink }}
+{{ if findRE "use-cases" $url }}
+  {{ $activeTema = "behov" }}
+{{ else if findRE "pilotering" $url }}
+  {{ $activeTema = "pilotering" }}
+{{ else if findRE "arkitektur" $url }}
+  {{ $activeTema = "arkitektur" }}
+{{ else if findRE "loesning" $url }}
+  {{ $activeTema = "loesning" }}
+{{ end }}
+
+<div class="tema-switcher">
+  <div class="tema-switcher-toggle" id="tema-toggle">
+    <span class="tema-label">Tema:</span>
+    <span class="tema-active">{{ if eq $activeTema "behov" }}Behov{{ else if eq $activeTema "pilotering" }}Pilotering{{ else if eq $activeTema "arkitektur" }}Arkitektur{{ else if eq $activeTema "loesning" }}Løsning{{ else }}Velg tema{{ end }}</span>
+    <i class="fa fa-caret-down"></i>
+  </div>
+  <ul class="tema-switcher-menu" id="tema-menu">
+    <li class="{{ if eq $activeTema "behov" }}active{{ end }}">
+      <a href="{{ "use-cases/" | relURL }}">
+        <i class="fa fa-lightbulb-o"></i>
+        <span>Behov</span>
+        {{ if eq $activeTema "behov" }}<i class="fa fa-check"></i>{{ end }}
+      </a>
+    </li>
+    <li class="disabled">
+      <span class="tema-disabled-item">
+        <i class="fa fa-flask"></i>
+        <span>Pilotering</span>
+      </span>
+    </li>
+    <li class="disabled">
+      <span class="tema-disabled-item">
+        <i class="fa fa-sitemap"></i>
+        <span>Arkitektur</span>
+      </span>
+    </li>
+    <li class="disabled">
+      <span class="tema-disabled-item">
+        <i class="fa fa-cogs"></i>
+        <span>Løsning</span>
+      </span>
+    </li>
+  </ul>
+</div>

--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -15,6 +15,7 @@
             <span style="color: #fff; font-size: 1.8rem; font-weight: bold;">{{ .Site.Title }}</span>
           </a>
           <div class="a-header-actions">
+            {{ partial "tema-switcher.html" . }}
             {{if not .Site.Params.noSearch}}
               {{ partial "search.html" . }}
             {{end}}


### PR DESCRIPTION
Legger til en "Tema"-nedtrekksmeny i headeren (lik Altinn sin produktvelger) med fire toppnivåvalg:
- Behov (aktiv, lenker til use-cases)
- Pilotering (disabled)
- Arkitektur (disabled)
- Løsning (disabled)

Strukturen er designet med tanke på fremtidig Antora-migrasjon, der hvert tema tilsvarer en Antora-komponent.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx