### PR TITLE
Finjuster navigasjon, menyvisning og footer

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: "Welcome"
+title: "Documentation"
 draft: false
 ---
 

--- a/content/_index.nb.md
+++ b/content/_index.nb.md
@@ -1,5 +1,5 @@
 ---
-title: "Velkommen"
+title: "Dokumentasjon"
 draft: false
 ---
 

--- a/content/behov/_index.en.md
+++ b/content/behov/_index.en.md
@@ -2,6 +2,7 @@
 title: "Needs"
 linkTitle: "Needs"
 weight: 10
+alwaysopen: true
 ---
 
 Mapping of needs for collaboration within childhood development and education.

--- a/content/behov/_index.nb.md
+++ b/content/behov/_index.nb.md
@@ -2,6 +2,7 @@
 title: "Behov"
 linkTitle: "Behov"
 weight: 10
+alwaysopen: true
 ---
 
 Kartlegging av behov for samhandling innen oppvekst og utdanning.

--- a/content/behov/use-cases/_index.en.md
+++ b/content/behov/use-cases/_index.en.md
@@ -2,6 +2,7 @@
 title: "Use Cases"
 linkTitle: "Use Cases"
 weight: 30
+alwaysopen: true
 ---
 
 Overview of identified use cases for collaboration within childhood development and education.

--- a/content/behov/use-cases/_index.nb.md
+++ b/content/behov/use-cases/_index.nb.md
@@ -2,6 +2,7 @@
 title: "Use cases"
 linkTitle: "Use cases"
 weight: 30
+alwaysopen: true
 ---
 
 Oversikt over identifiserte brukssaker for samhandling innen oppvekst og utdanning.

--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -2,8 +2,8 @@
     <div class="container">
         <div class="row">
             <div class="col-12">
-                <nav class="a-footerExtraNav">
-                    SAMT-BU
+                <nav class="a-footerExtraNav" style="text-align: center;">
+                    SAMT-BU: Sammenhengende tjenester for barn og unge
                 </nav>
             </div>
         </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -55,10 +55,7 @@
           <div id="content" class="adocs-content js-moveChildrenTo">
         <div id="overlay"></div>
         <div class="a-text">
-        {{if not .IsHome}}
           <div id="top-bar">
-
-
             <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
                 <span id="sidebar-toggle-span" class="adocs-sidebarToggle">
                   <a href="#" id="sidebar-toggle" data-sidebar-toggle="">
@@ -68,15 +65,16 @@
                 </span>
                 <span class="links">
                   <a href="{{ "/" | relURL }}" class="breadcrumb-home"><i class="fa fa-home"></i></a>
+                  {{if not .IsHome}}
                   <span class="adocs-breadcrumb-divider"> / </span>
                   {{if eq .Kind "taxonomy"}}
                     <a href="/docs/tags/">Tags</a> /
                   {{end}}
                   {{ template "breadcrumb" dict "page" . "value" .LinkTitle }}
+                  {{end}}
                 </span>
             </div>
           </div>
-        {{end}}
         {{if .Params.tags }}
           <div id="tags">
             {{ range $index, $tag := .Params.tags }}


### PR DESCRIPTION
- Endre hjemmeside-tittel fra 'Velkommen' til 'Dokumentasjon' (vises i brødsmulesti)
- Vis hus-ikon og brødsmulesti også på hjemmesiden
- Sett alwaysopen på Behov og Use cases slik at menyen er utfoldet som standard
- Midtstill footer og utvid til 'SAMT-BU: Sammenhengende tjenester for barn og unge'

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx