### PR TITLE
Legg til Status-metadatafelt og Unicode-statussymboler i menyen

### DIFF
--- a/content/behov/use-cases/01-resultater-vgo/_index.nb.md
+++ b/content/behov/use-cases/01-resultater-vgo/_index.nb.md
@@ -1,8 +1,9 @@
 ---
 title: "1. Tilgjengeliggjøring av resultater fra videregående opplæring"
-linkTitle: "1. Resultater fra VGO"
+linkTitle: "◐ 1. Resultater fra VGO"
 weight: 1
 toc: true
+status: "Første utkast"
 ---
 
 ## Kort beskrivelse

--- a/content/behov/use-cases/02-overgang-grunnskole-vgo/_index.nb.md
+++ b/content/behov/use-cases/02-overgang-grunnskole-vgo/_index.nb.md
@@ -1,8 +1,9 @@
 ---
 title: "2. Sømløs overgang fra grunnskole til videregående opplæring"
-linkTitle: "2. Overgang grunnskole–VGO"
+linkTitle: "◐ 2. Overgang grunnskole–VGO"
 weight: 2
 toc: true
+status: "Første utkast"
 ---
 
 ## Kort beskrivelse

--- a/content/behov/use-cases/03-id-haandtering-flyktninger/_index.nb.md
+++ b/content/behov/use-cases/03-id-haandtering-flyktninger/_index.nb.md
@@ -1,8 +1,9 @@
 ---
 title: "3. Håndtering av D-nummer og ID-bytte"
-linkTitle: "3. Håndtering av Dnr"
+linkTitle: "◐ 3. Håndtering av Dnr"
 weight: 3
 toc: true
+status: "Første utkast"
 ---
 
 ## Kort beskrivelse

--- a/content/behov/use-cases/04-flytting-elever/_index.nb.md
+++ b/content/behov/use-cases/04-flytting-elever/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "4. Flytting av elever i skoleåret mellom kommuner/fylkeskommuner"
-linkTitle: "4. Flytting av elever"
+linkTitle: "☐ 4. Flytting av elever"
 weight: 4
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Flytting av elever i skoleåret mellom kommuner og fylkeskommuner.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/05-samtykkeportal/_index.nb.md
+++ b/content/behov/use-cases/05-samtykkeportal/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "5. Samtykkeportal"
-linkTitle: "5. Samtykkeportal"
+linkTitle: "☐ 5. Samtykkeportal"
 weight: 5
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Samtykkeportal – sentralisert oversikt over samtykker. Videreutvikling av FIKS samtykke?
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/06-sentralisert-datatilgang/_index.nb.md
+++ b/content/behov/use-cases/06-sentralisert-datatilgang/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "6. Sentralisert tilgang til data foreldrene trenger"
-linkTitle: "6. Datatilgang for foreldre"
+linkTitle: "☐ 6. Datatilgang for foreldre"
 weight: 6
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Sentralisert tilgang til data foreldrene trenger – nasjonale prøver, kartlegging, sluttvurdering osv.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/07-tidlig-identifisering/_index.nb.md
+++ b/content/behov/use-cases/07-tidlig-identifisering/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "7. Tidlig identifisering av elever i faresonen"
-linkTitle: "7. Tidlig identifisering"
+linkTitle: "☐ 7. Tidlig identifisering"
 weight: 7
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Tidlig identifisering av elever i faresonen og videreføring av tiltak og data gjennom opplæringsløpet.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/08-overganger-utdanningsnivaaer/_index.nb.md
+++ b/content/behov/use-cases/08-overganger-utdanningsnivaaer/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "8. Overganger mellom utdanningsnivåer"
-linkTitle: "8. Overganger utdanningsnivåer"
+linkTitle: "☐ 8. Overganger utdanningsnivåer"
 weight: 8
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Overganger mellom utdanningsnivåer – fra barnehage til grunnskole, videre til videregående og høyere utdanning. For eksempel utveksling av elevinformasjon ved skolebytte.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/09-bytte-skole/_index.nb.md
+++ b/content/behov/use-cases/09-bytte-skole/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "9. Bytte av skole eller studiested"
-linkTitle: "9. Bytte skole/studiested"
+linkTitle: "☐ 9. Bytte skole/studiested"
 weight: 9
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Bytte av skole eller studiested.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/10-overgang-kommunale-tjenester/_index.nb.md
+++ b/content/behov/use-cases/10-overgang-kommunale-tjenester/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "10. Overgang til andre kommunale tjenester"
-linkTitle: "10. Kommunale tjenester"
+linkTitle: "☐ 10. Kommunale tjenester"
 weight: 10
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Overgang til andre kommunale tjenester som barnevern eller PPT.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/11-digital-dialog-hjem/_index.nb.md
+++ b/content/behov/use-cases/11-digital-dialog-hjem/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "11. Digital dialog mellom barnehage/skole og hjemmet"
-linkTitle: "11. Digital dialog hjem"
+linkTitle: "☐ 11. Digital dialog hjem"
 weight: 11
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Digital dialog og økt involvering mellom barnehage/skole og hjemmet (foresatte og elever).
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/12-endring-utdanningsloep/_index.nb.md
+++ b/content/behov/use-cases/12-endring-utdanningsloep/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "12. Endring av utdanningsløp eller studieretning"
-linkTitle: "12. Endring utdanningsløp"
+linkTitle: "☐ 12. Endring utdanningsløp"
 weight: 12
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Endring av utdanningsløp eller studieretning.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/13-avbrutt-utdanning/_index.nb.md
+++ b/content/behov/use-cases/13-avbrutt-utdanning/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "13. Avbrutt utdanning (frafall)"
-linkTitle: "13. Avbrutt utdanning"
+linkTitle: "☐ 13. Avbrutt utdanning"
 weight: 13
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Avbrutt utdanning (frafall).
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/14-vitnemaal-kompetansebevis/_index.nb.md
+++ b/content/behov/use-cases/14-vitnemaal-kompetansebevis/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "14. Dokumentasjon og deling av vitnemål og kompetansebevis"
-linkTitle: "14. Vitnemål og kompetansebevis"
+linkTitle: "☐ 14. Vitnemål og kompetansebevis"
 weight: 14
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Dokumentasjon og deling av vitnemål og kompetansebevis.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/15-anskaffelser-fagsystemer/_index.nb.md
+++ b/content/behov/use-cases/15-anskaffelser-fagsystemer/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "15. Anskaffelser av fag- og støttesystemer"
-linkTitle: "15. Anskaffelser fagsystemer"
+linkTitle: "☐ 15. Anskaffelser fagsystemer"
 weight: 15
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Anskaffelser av fag- og støttesystemer – økt grad av felles tilnærming og anskaffelser av fagsystemer gjennom definerte rammeverk, modeller og arkitektur.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/16-ki-loesninger/_index.nb.md
+++ b/content/behov/use-cases/16-ki-loesninger/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "16. KI-løsninger basert på felles informasjonsmodeller"
-linkTitle: "16. KI-løsninger"
+linkTitle: "☐ 16. KI-løsninger"
 weight: 16
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 KI-løsninger basert på strukturerte, felles informasjonsmodeller innen oppvekst og utdanning, i samarbeid med andre KI-initiativ.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/17-hendelsesdrevet-rapportering/_index.nb.md
+++ b/content/behov/use-cases/17-hendelsesdrevet-rapportering/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "17. Hendelsesdrevet og automatisert rapportering"
-linkTitle: "17. Automatisert rapportering"
+linkTitle: "☐ 17. Automatisert rapportering"
 weight: 17
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 Hendelsesdrevet og automatisert rapportering med MVP på ny løsning for dette – for eksempel rapportering til SSB/KOSTRA.
 
-## Status
-
-Ikke påbegynt.

--- a/content/behov/use-cases/18-saarbare-barn-skolen/_index.nb.md
+++ b/content/behov/use-cases/18-saarbare-barn-skolen/_index.nb.md
@@ -1,8 +1,9 @@
 ---
 title: "18. Innspill fra Utdanningsetaten i Oslo kommune"
-linkTitle: "18. UDE Oslo"
+linkTitle: "◐ 18. UDE Oslo"
 weight: 18
 toc: true
+status: "Første utkast"
 ---
 
 ## Kort beskrivelse

--- a/content/behov/use-cases/19-statped-soknader/_index.nb.md
+++ b/content/behov/use-cases/19-statped-soknader/_index.nb.md
@@ -1,18 +1,13 @@
 ---
 title: "19. StatPed – søknader fra PP-tjenesten"
-linkTitle: "19. StatPed-søknader"
+linkTitle: "☐ 19. StatPed-søknader"
 weight: 19
 toc: true
+status: "Detaljering gjenstår"
 ---
 
-{{% notice info %}}
-Denne brukssaken er under utarbeidelse.
-{{% /notice %}}
 
-## Beskrivelse
+## Foreløpig beskrivelse
 
 StatPed – søknader fra PP-tjenesten i kommunen om bistand.
 
-## Status
-
-Ikke påbegynt.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -101,6 +101,9 @@
               {{ if not .Lastmod.IsZero }}
                 <span class="page-meta-lastmod">{{T "Last-modified"}}: {{ .Lastmod.Format "2006-01-02 15:04" }}</span>
               {{ end }}
+              {{ with .Params.status }}
+                <span class="page-meta-status">Status: {{ . }}</span>
+              {{ end }}
             </div>
           {{end}}
 


### PR DESCRIPTION
- Nytt 'status'-felt i frontmatter, vist under 'Sist endret' i page-meta-raden
- #1, #2, #3, #18: status 'Første utkast' med ◐ symbol
- Resten: status 'Detaljering gjenstår' med ☐ symbol
- Fjerner notice-blokk og '## Status'-kapittel fra placeholder-sider
- Renamer '## Beskrivelse' til '## Foreløpig beskrivelse'

Statussymboler i bruk:
  ☐ = Detaljering gjenstår ◐ = Første utkast ✔ = Godkjent (fremtidig) ⊘ = Ikke lenger aktuell (fremtidig)

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx