### PR TITLE
Fiks CI: legg til retry-logikk for Hugo-nedlasting og fjern Go-avheng…

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -26,14 +26,12 @@ jobs:
     steps:
       - name: Install Hugo CLI
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-          cache: false
+          for i in 1 2 3; do
+            wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb && break
+            echo "Attempt $i failed, retrying in $((i * 5)) seconds..."
+            sleep $((i * 5))
+          done
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
…ighet

Hugo-nedlastingen feilet med exit code 8 (serverfeil) i run #32. Legger til retry med økende ventetid (5s, 10s, 15s) for å håndtere forbigående nettverksfeil. Fjerner Go-installasjonen som ikke trengs siden temaet brukes via git submodule, ikke Hugo Modules.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx