### PR TITLE
Utvid med alle 6 temaer i venstremeny og tema-switcher

### DIFF
--- a/content/arkitektur/_index.en.md
+++ b/content/arkitektur/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: "Architecture"
+linkTitle: "Architecture"
+weight: 30
+status: "Not started"
+---
+

--- a/content/arkitektur/_index.nb.md
+++ b/content/arkitektur/_index.nb.md
@@ -1,0 +1,7 @@
+---
+title: "Arkitektur"
+linkTitle: "Arkitektur"
+weight: 30
+status: "Ikke påbegynt"
+---
+

--- a/content/behov/_index.en.md
+++ b/content/behov/_index.en.md
@@ -3,6 +3,7 @@ title: "Needs"
 linkTitle: "Needs"
 weight: 10
 alwaysopen: true
+status: "I arbeid"
 ---
 
 Mapping of needs for collaboration within childhood development and education.

--- a/content/behov/_index.nb.md
+++ b/content/behov/_index.nb.md
@@ -3,6 +3,7 @@ title: "Behov"
 linkTitle: "Behov"
 weight: 10
 alwaysopen: true
+status: "I arbeid"
 ---
 
 Kartlegging av behov for samhandling innen oppvekst og utdanning.

--- a/content/behov/use-cases/_index.en.md
+++ b/content/behov/use-cases/_index.en.md
@@ -3,6 +3,7 @@ title: "Use Cases"
 linkTitle: "Use Cases"
 weight: 30
 alwaysopen: true
+status: "I arbeid"
 ---
 
 Overview of identified use cases for collaboration within childhood development and education.

--- a/content/behov/use-cases/_index.nb.md
+++ b/content/behov/use-cases/_index.nb.md
@@ -3,6 +3,7 @@ title: "Use cases"
 linkTitle: "Use cases"
 weight: 30
 alwaysopen: true
+status: "I arbeid"
 ---
 
 Oversikt over identifiserte brukssaker for samhandling innen oppvekst og utdanning.

--- a/content/informasjonsmodeller/_index.en.md
+++ b/content/informasjonsmodeller/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: "Information Models"
+linkTitle: "Information Models"
+weight: 60
+status: "Not started"
+---
+

--- a/content/informasjonsmodeller/_index.nb.md
+++ b/content/informasjonsmodeller/_index.nb.md
@@ -1,0 +1,7 @@
+---
+title: "Informasjonsmodeller"
+linkTitle: "Informasjonsmodeller"
+weight: 60
+status: "Ikke påbegynt"
+---
+

--- a/content/loesning/_index.en.md
+++ b/content/loesning/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: "Solution"
+linkTitle: "Solution"
+weight: 40
+status: "Not started"
+---
+

--- a/content/loesning/_index.nb.md
+++ b/content/loesning/_index.nb.md
@@ -1,0 +1,7 @@
+---
+title: "Løsning"
+linkTitle: "Løsning"
+weight: 40
+status: "Ikke påbegynt"
+---
+

--- a/content/pilotering/_index.en.md
+++ b/content/pilotering/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: "Piloting"
+linkTitle: "Piloting"
+weight: 20
+status: "Not started"
+---
+

--- a/content/pilotering/_index.nb.md
+++ b/content/pilotering/_index.nb.md
@@ -1,0 +1,7 @@
+---
+title: "Pilotering"
+linkTitle: "Pilotering"
+weight: 20
+status: "Ikke påbegynt"
+---
+

--- a/content/rammeverk/_index.en.md
+++ b/content/rammeverk/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: "Framework"
+linkTitle: "Framework"
+weight: 50
+status: "Not started"
+---
+

--- a/content/rammeverk/_index.nb.md
+++ b/content/rammeverk/_index.nb.md
@@ -1,0 +1,7 @@
+---
+title: "Rammeverk"
+linkTitle: "Rammeverk"
+weight: 50
+status: "Ikke påbegynt"
+---
+

--- a/layouts/partials/tema-switcher.html
+++ b/layouts/partials/tema-switcher.html
@@ -9,12 +9,16 @@
   {{ $activeTema = "arkitektur" }}
 {{ else if findRE "loesning" $url }}
   {{ $activeTema = "loesning" }}
+{{ else if findRE "rammeverk" $url }}
+  {{ $activeTema = "rammeverk" }}
+{{ else if findRE "informasjonsmodeller" $url }}
+  {{ $activeTema = "informasjonsmodeller" }}
 {{ end }}
 
 <div class="tema-switcher">
   <div class="tema-switcher-toggle" id="tema-toggle">
     <span class="tema-label">Tema:</span>
-    <span class="tema-active">{{ if eq $activeTema "behov" }}Behov{{ else if eq $activeTema "pilotering" }}Pilotering{{ else if eq $activeTema "arkitektur" }}Arkitektur{{ else if eq $activeTema "loesning" }}Løsning{{ else }}Velg tema{{ end }}</span>
+    <span class="tema-active">{{ if eq $activeTema "behov" }}Behov{{ else if eq $activeTema "pilotering" }}Pilotering{{ else if eq $activeTema "arkitektur" }}Arkitektur{{ else if eq $activeTema "loesning" }}Løsning{{ else if eq $activeTema "rammeverk" }}Rammeverk{{ else if eq $activeTema "informasjonsmodeller" }}Informasjonsmodeller{{ else }}Velg tema{{ end }}</span>
     <i class="fa fa-caret-down"></i>
   </div>
   <ul class="tema-switcher-menu" id="tema-menu">
@@ -25,23 +29,40 @@
         {{ if eq $activeTema "behov" }}<i class="fa fa-check"></i>{{ end }}
       </a>
     </li>
-    <li class="disabled">
-      <span class="tema-disabled-item">
+    <li class="{{ if eq $activeTema "pilotering" }}active{{ end }}">
+      <a href="{{ "pilotering/" | relURL }}">
         <i class="fa fa-flask"></i>
         <span>Pilotering</span>
-      </span>
+        {{ if eq $activeTema "pilotering" }}<i class="fa fa-check"></i>{{ end }}
+      </a>
     </li>
-    <li class="disabled">
-      <span class="tema-disabled-item">
+    <li class="{{ if eq $activeTema "arkitektur" }}active{{ end }}">
+      <a href="{{ "arkitektur/" | relURL }}">
         <i class="fa fa-sitemap"></i>
         <span>Arkitektur</span>
-      </span>
+        {{ if eq $activeTema "arkitektur" }}<i class="fa fa-check"></i>{{ end }}
+      </a>
     </li>
-    <li class="disabled">
-      <span class="tema-disabled-item">
+    <li class="{{ if eq $activeTema "loesning" }}active{{ end }}">
+      <a href="{{ "loesning/" | relURL }}">
         <i class="fa fa-cogs"></i>
         <span>Løsning</span>
-      </span>
+        {{ if eq $activeTema "loesning" }}<i class="fa fa-check"></i>{{ end }}
+      </a>
+    </li>
+    <li class="{{ if eq $activeTema "rammeverk" }}active{{ end }}">
+      <a href="{{ "rammeverk/" | relURL }}">
+        <i class="fa fa-cubes"></i>
+        <span>Rammeverk</span>
+        {{ if eq $activeTema "rammeverk" }}<i class="fa fa-check"></i>{{ end }}
+      </a>
+    </li>
+    <li class="{{ if eq $activeTema "informasjonsmodeller" }}active{{ end }}">
+      <a href="{{ "informasjonsmodeller/" | relURL }}">
+        <i class="fa fa-database"></i>
+        <span>Informasjonsmodeller</span>
+        {{ if eq $activeTema "informasjonsmodeller" }}<i class="fa fa-check"></i>{{ end }}
+      </a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
- Opprett innholdssider for Pilotering, Arkitektur, Løsning, Rammeverk og Informasjonsmodeller (status: Ikke påbegynt)
- Aktiver alle temaer som klikkbare lenker i tema-dropdown
- Legg til status "I arbeid" i frontmatter for Behov og Use cases

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx