### PR TITLE
Flytt «⚒ Nettsted under etablering» til det blå header-feltet

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -3,6 +3,4 @@ title: "Documentation"
 draft: false
 ---
 
-⚒ **Site under construction**
-
 Welcome to SAMT-BU documentation.

--- a/content/_index.nb.md
+++ b/content/_index.nb.md
@@ -3,6 +3,4 @@ title: "Dokumentasjon"
 draft: false
 ---
 
-⚒ **Nettsted under etablering**
-
 Velkommen til SAMT-BU dokumentasjon.

--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -13,6 +13,7 @@
           <a href="{{ with .Site.GetPage "/" }}{{ .RelPermalink }}{{ end }}" class="a-globalNav-logo" style="display: flex; align-items: center; text-decoration: none;">
             <img src="{{ "images/SAMT-BU-logo.png" | relURL }}" alt="SAMT-BU logo" class="a-logo a-modal-top-logo" style="height: 40px; width: auto; margin-right: 10px; filter: brightness(0) invert(1);">
             <span style="color: #fff; font-size: 1.8rem; font-weight: bold;">{{ .Site.Title }}</span>
+            <span style="color: #fff; font-size: 0.9rem; opacity: 0.85; margin-left: 16px;">⚒ Nettsted under etablering</span>
           </a>
           <div class="a-header-actions">
             {{ partial "tema-switcher.html" . }}


### PR DESCRIPTION
Vises nå i hvitt til høyre for «SAMT-BU Dokumentasjon» i topbaren, og fjernet fra forsideinnholdet.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx