### PR TITLE
Gjør «⚒ Nettsted under etablering» større, rød, midtstilt og hevet

### DIFF
--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -9,12 +9,12 @@
   <div class="container">
     <div class="row">
       <div class="col-12">
-        <nav class="a-globalNav" id="primary-nav" style="display: flex; align-items: center; justify-content: space-between;">
+        <nav class="a-globalNav" id="primary-nav" style="display: flex; align-items: center; justify-content: space-between; position: relative;">
           <a href="{{ with .Site.GetPage "/" }}{{ .RelPermalink }}{{ end }}" class="a-globalNav-logo" style="display: flex; align-items: center; text-decoration: none;">
             <img src="{{ "images/SAMT-BU-logo.png" | relURL }}" alt="SAMT-BU logo" class="a-logo a-modal-top-logo" style="height: 40px; width: auto; margin-right: 10px; filter: brightness(0) invert(1);">
             <span style="color: #fff; font-size: 1.8rem; font-weight: bold;">{{ .Site.Title }}</span>
-            <span style="color: #fff; font-size: 0.9rem; opacity: 0.85; margin-left: 16px;">⚒ Nettsted under etablering</span>
           </a>
+          <span style="position: absolute; left: 50%; transform: translateX(-50%) translateY(-2px); color: #ff4444; font-size: 1.3rem; font-weight: bold; white-space: nowrap;">⚒ Nettsted under etablering</span>
           <div class="a-header-actions">
             {{ partial "tema-switcher.html" . }}
             {{if not .Site.Params.noSearch}}


### PR DESCRIPTION
Teksten er nå midtstilt horisontalt i headeren, i rødt, med større fontstørrelse og litt hevet vertikalt.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx