### PR TITLE
Forstørr hammersymbolet og hev teksten mot toppen av headeren

### DIFF
--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -14,7 +14,7 @@
             <img src="{{ "images/SAMT-BU-logo.png" | relURL }}" alt="SAMT-BU logo" class="a-logo a-modal-top-logo" style="height: 40px; width: auto; margin-right: 10px; filter: brightness(0) invert(1);">
             <span style="color: #fff; font-size: 1.8rem; font-weight: bold;">{{ .Site.Title }}</span>
           </a>
-          <span style="position: absolute; left: 50%; transform: translateX(-50%) translateY(-2px); color: #ff4444; font-size: 1.3rem; font-weight: bold; white-space: nowrap;">⚒ Nettsted under etablering</span>
+          <span style="position: absolute; left: 50%; transform: translateX(-50%); color: #ff4444; font-size: 1.3rem; font-weight: bold; white-space: nowrap; top: 4px;"><span style="font-size: 2.6rem; line-height: 1; vertical-align: middle;">⚒</span> Nettsted under etablering</span>
           <div class="a-header-actions">
             {{ partial "tema-switcher.html" . }}
             {{if not .Site.Params.noSearch}}


### PR DESCRIPTION
Hammer-unicode er nå dobbelt så stor (2.6rem vs 1.3rem) uten å endre skriftstørrelsen på teksten. Hele elementet er hevet til overkant av headeren med top: 4px.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx