### PR TITLE
Juster vertikal sentrering, hev mer og flytt litt til venstre

### DIFF
--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -14,7 +14,7 @@
             <img src="{{ "images/SAMT-BU-logo.png" | relURL }}" alt="SAMT-BU logo" class="a-logo a-modal-top-logo" style="height: 40px; width: auto; margin-right: 10px; filter: brightness(0) invert(1);">
             <span style="color: #fff; font-size: 1.8rem; font-weight: bold;">{{ .Site.Title }}</span>
           </a>
-          <span style="position: absolute; left: 50%; transform: translateX(-50%); color: #ff4444; font-size: 1.3rem; font-weight: bold; white-space: nowrap; top: 4px;"><span style="font-size: 2.6rem; line-height: 1; vertical-align: middle;">⚒</span> Nettsted under etablering</span>
+          <span style="position: absolute; left: 42%; transform: translateX(-50%); color: #ff4444; font-size: 1.3rem; font-weight: bold; white-space: nowrap; top: 2px; display: flex; align-items: center;"><span style="font-size: 2.6rem; line-height: 1;">⚒</span><span style="margin-left: 6px;">Nettsted under etablering</span></span>
           <div class="a-header-actions">
             {{ partial "tema-switcher.html" . }}
             {{if not .Site.Params.noSearch}}


### PR DESCRIPTION
- Bruker flex + align-items:center for å midtstille teksten vertikalt ift. hammersymbolet
- Hevet mer mot toppen (top: 2px) slik at symbolet flukter med søkefeltet
- Flyttet til venstre (left: 42%) for bedre grafisk tyngdepunkt

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx