### PR TITLE
Legg til «Temaer»-overskrift i venstremenyen og reduser header-avstand

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -242,6 +242,16 @@
     }
   }
 
+  /* Left sidebar heading (matches #page-toc h3) */
+  #sidebar .sidebar-heading {
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 0;
+    margin-bottom: 8px;
+    color: #333;
+    padding-left: 16px;
+  }
+
   /* Right-side Table of Contents */
   #page-toc {
     position: sticky;

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -44,7 +44,7 @@
       {{ partial "jumbotron.html" . }}
     {{end}}
 
-    <div class="container pt-2 pt-md-3 pt-lg-5">
+    <div class="container pt-2 pt-md-2 pt-lg-3">
       <div class="adocs-scrollcontainer">
         <div class="row">
             <div class="col-sm-12">

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -7,7 +7,7 @@
 <div class="highlightable">
   <div id="header-wrapper">
   </div>
-
+  <h3 class="sidebar-heading">{{ cond (eq .Site.Language.Lang "nb") "Temaer" "Topics" }}</h3>
 
     <ul id="docsmenu" class="topics">
 


### PR DESCRIPTION
- Ny h3 «Temaer» over menylinjen i venstre kolonne, med samme font/størrelse som «På denne siden» (14px bold #333)
- Redusert padding mellom blå header og innholdsområdet (pt-lg-5 → pt-lg-3, pt-md-3 → pt-md-2)

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx