### PR TITLE
Sett sidebar-fontstørrelse til 13px for å matche høyre kolonne

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -227,6 +227,7 @@
       flex: 0 0 20%;
       min-width: 180px;
       max-width: 260px;
+      font-size: 13px;
     }
     .body-toc-wrapper {
       flex: 1;


### PR DESCRIPTION
Venstremenyen arvet temats standardfont som var for stor. Satt til 13px, samme som #page-toc.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx