### PR TITLE
Fiks font og størrelse på punktlister i midtkolonnen

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -190,6 +190,12 @@
   .a-text ol {
     font-size: 16px;
   }
+  #body ul,
+  #body ol,
+  #body li {
+    font-size: 16px;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  }
 
   /* Remove blue border-bottom from breadcrumb and TOC links
      (designsystem.css sets border-bottom: 2px solid #1EAEF7 on all <a>) */


### PR DESCRIPTION
Lister i #body arvet en annen/større font fra temaet. Setter eksplisitt 16px og standard sans-serif font for ul, ol og li i innholdsområdet.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx