### PR TITLE
Fiks font i punktlister med !important for å overstyre designsystem

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -187,14 +187,13 @@
   .a-text,
   .a-text p,
   .a-text li,
-  .a-text ol {
-    font-size: 16px;
-  }
+  .a-text ol,
+  .a-text ul:not(.connected-bullets):not(.no-decoration):not(.a-list) li,
   #body ul,
   #body ol,
   #body li {
-    font-size: 16px;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 16px !important;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
   }
 
   /* Remove blue border-bottom from breadcrumb and TOC links


### PR DESCRIPTION
Designsystemets media query setter .a-text li til 18px/1.8rem på skjermer >= 768px. Bruker nå !important for å tvinge 16px og standard sans-serif font på alle lister i innholdsområdet.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx