### PR TITLE
Reduser linjeavstand mellom og foran bullet points

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -195,6 +195,16 @@
     font-size: 16px !important;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
   }
+  /* Tighter spacing for bullet/numbered lists */
+  .a-text ul:not(.connected-bullets):not(.no-decoration):not(.a-list) {
+    margin-top: 4px !important;
+  }
+  .a-text ul:not(.connected-bullets):not(.no-decoration):not(.a-list) li,
+  .a-text ol li,
+  #body ul li,
+  #body ol li {
+    margin-bottom: 4px !important;
+  }
 
   /* Remove blue border-bottom from breadcrumb and TOC links
      (designsystem.css sets border-bottom: 2px solid #1EAEF7 on all <a>) */


### PR DESCRIPTION
Designsystemet setter margin-bottom: 12px og margin-top: 12px på listelementer. Redusert til 4px for tettere, mer lesbar layout.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx