### PR TITLE
Reduser linjeavstand i venstremenyen til å matche punktlister

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -283,10 +283,10 @@
 
   /* Tighter spacing for sidebar menu items */
   #sidebar ul li a {
-    padding: 5px 9px !important;
+    padding: 2px 9px !important;
   }
   #sidebar ul ul li > a {
-    padding: 3px 6px !important;
+    padding: 2px 6px !important;
   }
 
   /* Left sidebar heading (matches #page-toc h3) */


### PR DESCRIPTION
Padding på menylenker ned fra 5px/3px til 2px for å gi samme tette linjeavstand som bullet points i midtkolonnen.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx