### PR TITLE
Fjern dobbel vertikal linje i høyre TOC permanent

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -255,6 +255,11 @@
   #page-toc a:focus {
     border: none !important;
   }
+  #page-toc #TableOfContents,
+  #page-toc #TableOfContents ul,
+  #page-toc #TableOfContents li {
+    border: none !important;
+  }
 
   /* 3-column proportional flex layout: sidebar | content | TOC
      Uses percentages so column ratios hold when zooming */


### PR DESCRIPTION
Legger til border: none !important på #TableOfContents, ul og li i tillegg til a-elementer, for å fjerne alle mulige kilder til den ekstra linjen.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx