### PR TITLE
Fjern dobbel vertikal linje i TOC ved hover - sterkere override

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -254,6 +254,10 @@
   #page-toc a:active,
   #page-toc a:focus {
     border: none !important;
+    border-bottom: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+    padding-bottom: 0 !important;
   }
   #page-toc #TableOfContents,
   #page-toc #TableOfContents ul,
@@ -364,8 +368,8 @@
     color: #000;
     text-decoration: underline !important;
     border: none !important;
-  }
-    padding-bottom: 1px;
+    border-bottom: none !important;
+    padding-bottom: 0 !important;
   }
   /* Page metadata row below title (extensible with status etc.) */
   .page-meta {


### PR DESCRIPTION
Designsystemet setter border-bottom, padding-bottom og position på alle <a>. Overstyrer nå alle mulige kilder: border, border-bottom, outline, box-shadow og padding-bottom med !important. Fjernet også løs CSS-linje.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx