### PR TITLE
Skjul scrollbar i høyre TOC som skapte dobbel vertikal linje

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -324,6 +324,11 @@
     border-left: 2px solid #e0e0e0;
     max-height: 85vh;
     overflow-y: auto;
+    scrollbar-width: none;        /* Firefox */
+    -ms-overflow-style: none;     /* IE/Edge */
+  }
+  #page-toc::-webkit-scrollbar {
+    display: none;                /* Chrome/Safari */
   }
   #page-toc h3 {
     font-size: 14px;


### PR DESCRIPTION
Overlay-scrollbaren fra overflow-y:auto dukket opp ved hover og så ut som en ekstra vertikal linje. Skjuler scrollbar visuelt mens scroll-funksjonalitet beholdes.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx