### PR TITLE
Fjern scrollbar på #TableOfContents som skapte gjenværende linje

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -340,6 +340,8 @@
   #page-toc #TableOfContents {
     font-size: 13px;
     padding: 0;
+    overflow: visible !important;
+    max-height: none !important;
   }
   #page-toc #TableOfContents ul {
     list-style: none;


### PR DESCRIPTION
theme.css setter overflow:auto og max-height:85vh på både #page-toc og #TableOfContents — to scrollbarer oppå hverandre. Fjerner overflow/max-height på indre element siden ytre allerede håndterer scroll.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx