### PR TITLE
Vis tynn scrollbar i høyre TOC kun ved hover

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -324,11 +324,25 @@
     border-left: 2px solid #e0e0e0;
     max-height: 85vh;
     overflow-y: auto;
-    scrollbar-width: none;        /* Firefox */
+    scrollbar-width: none;        /* Firefox: hidden by default */
     -ms-overflow-style: none;     /* IE/Edge */
   }
   #page-toc::-webkit-scrollbar {
-    display: none;                /* Chrome/Safari */
+    width: 0;                     /* Chrome/Safari: hidden by default */
+  }
+  #page-toc:hover {
+    scrollbar-width: thin;        /* Firefox: show thin scrollbar on hover */
+    scrollbar-color: #ccc transparent;
+  }
+  #page-toc:hover::-webkit-scrollbar {
+    width: 4px;
+  }
+  #page-toc:hover::-webkit-scrollbar-thumb {
+    background-color: #ccc;
+    border-radius: 4px;
+  }
+  #page-toc:hover::-webkit-scrollbar-track {
+    background: transparent;
   }
   #page-toc h3 {
     font-size: 14px;


### PR DESCRIPTION
Scrollbar skjult som standard, men vises som en tynn (4px), subtil grå scrollbar når musen er over TOC-området. Støtter Firefox (scrollbar-width), Chrome/Safari (webkit) og IE/Edge.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx