### PR TITLE
Fiks TOC scrollbar: alltid tilstede men usynlig til hover

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -324,25 +324,25 @@
     border-left: 2px solid #e0e0e0;
     max-height: 85vh;
     overflow-y: auto;
-    scrollbar-width: none;        /* Firefox: hidden by default */
-    -ms-overflow-style: none;     /* IE/Edge */
-  }
-  #page-toc::-webkit-scrollbar {
-    width: 0;                     /* Chrome/Safari: hidden by default */
+    scrollbar-width: thin;                /* Firefox: always thin */
+    scrollbar-color: transparent transparent; /* Firefox: invisible by default */
   }
   #page-toc:hover {
-    scrollbar-width: thin;        /* Firefox: show thin scrollbar on hover */
-    scrollbar-color: #ccc transparent;
+    scrollbar-color: rgba(0,0,0,0.25) transparent; /* Firefox: visible on hover */
   }
-  #page-toc:hover::-webkit-scrollbar {
-    width: 4px;
+  #page-toc::-webkit-scrollbar {
+    width: 6px;                           /* Chrome/Safari: always present */
+  }
+  #page-toc::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  #page-toc::-webkit-scrollbar-thumb {
+    background-color: transparent;        /* Invisible by default */
+    border-radius: 3px;
+    transition: background-color 0.2s;
   }
   #page-toc:hover::-webkit-scrollbar-thumb {
-    background-color: #ccc;
-    border-radius: 4px;
-  }
-  #page-toc:hover::-webkit-scrollbar-track {
-    background: transparent;
+    background-color: rgba(0,0,0,0.25);  /* Visible on hover */
   }
   #page-toc h3 {
     font-size: 14px;


### PR DESCRIPTION
Scrollbar har nå fast bredde (6px) hele tiden, men thumb er transparent som standard. Når musen er over TOC-området blir thumb synlig (rgba). Dette unngår problemet med å endre scrollbar-bredde dynamisk som ikke fungerer godt i webkit.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx