### PR TITLE
TOC scroll-hint: skjult scrollbar med gradient-fade i bunn

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -324,25 +324,26 @@
     border-left: 2px solid #e0e0e0;
     max-height: 85vh;
     overflow-y: auto;
-    scrollbar-width: thin;                /* Firefox: always thin */
-    scrollbar-color: transparent transparent; /* Firefox: invisible by default */
-  }
-  #page-toc:hover {
-    scrollbar-color: rgba(0,0,0,0.25) transparent; /* Firefox: visible on hover */
+    /* Completely hidden scrollbar */
+    scrollbar-width: none;               /* Firefox */
   }
   #page-toc::-webkit-scrollbar {
-    width: 6px;                           /* Chrome/Safari: always present */
+    display: none;                        /* Chrome/Safari */
   }
-  #page-toc::-webkit-scrollbar-track {
-    background: transparent;
+  /* Scroll-hint: gradient fade at bottom when more content below */
+  .toc-scroll-fade {
+    pointer-events: none;
+    position: sticky;
+    bottom: 0;
+    display: block;
+    height: 36px;
+    margin: 0 -16px;           /* stretch to fill padding */
+    padding: 0 16px;
+    background: linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 60%, rgba(255,255,255,1) 100%);
+    transition: opacity 0.3s;
   }
-  #page-toc::-webkit-scrollbar-thumb {
-    background-color: transparent;        /* Invisible by default */
-    border-radius: 3px;
-    transition: background-color 0.2s;
-  }
-  #page-toc:hover::-webkit-scrollbar-thumb {
-    background-color: rgba(0,0,0,0.25);  /* Visible on hover */
+  .toc-scroll-fade.hidden {
+    opacity: 0;
   }
   #page-toc h3 {
     font-size: 14px;

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -67,6 +67,7 @@
             <aside id="page-toc">
               <h3>{{ cond (eq .Page.Language.Lang "nb") "På denne siden" "On this page" }}</h3>
               {{ .TableOfContents }}
+              <div class="toc-scroll-fade" aria-hidden="true"></div>
             </aside>
           {{ end }}
         </div><!-- End body-toc-wrapper -->
@@ -110,6 +111,24 @@
     <script>mermaid.initialize({startOnLoad:true});</script>
 
     {{ partial "custom-footer.html" . }}
+
+    <script>
+    // TOC scroll-hint: hide fade when scrolled to bottom, show when more content below
+    (function() {
+      var toc = document.getElementById('page-toc');
+      if (!toc) return;
+      var fade = toc.querySelector('.toc-scroll-fade');
+      if (!fade) return;
+      function update() {
+        var atBottom = toc.scrollHeight - toc.scrollTop - toc.clientHeight < 4;
+        var noOverflow = toc.scrollHeight <= toc.clientHeight;
+        fade.classList.toggle('hidden', atBottom || noOverflow);
+      }
+      toc.addEventListener('scroll', update);
+      window.addEventListener('resize', update);
+      update();
+    })();
+    </script>
 
   </body>
 </html>


### PR DESCRIPTION
Bytter fra hover-scrollbar (alt #2) til scroll-hint (alt #1):
- Skjuler scrollbar helt (scrollbar-width: none)
- Legger til en gradient fade-effekt i bunnen av TOC som antyder at det er mer innhold å scrolle til
- Faden forsvinner automatisk når man scroller til bunnen eller når innholdet ikke er langt nok til å scrolle

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx