### PR TITLE
Sidebar: sticky med egen scroll, fade scroll-hint, fjern StickySidebar

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -278,6 +278,14 @@
       min-width: 180px;
       max-width: 260px;
       font-size: 15px;
+      position: sticky;
+      top: 20px;
+      max-height: 90vh;
+      overflow-y: auto;
+      scrollbar-width: none;             /* Firefox */
+    }
+    #sidebar::-webkit-scrollbar {
+      display: none;                      /* Chrome/Safari */
     }
     .body-toc-wrapper {
       flex: 1;
@@ -331,18 +339,22 @@
     display: none;                        /* Chrome/Safari */
   }
   /* Scroll-hint: gradient fade at bottom when more content below */
-  .toc-scroll-fade {
+  .toc-scroll-fade,
+  .sidebar-scroll-fade {
     pointer-events: none;
     position: sticky;
     bottom: 0;
     display: block;
     height: 36px;
-    margin: 0 -16px;           /* stretch to fill padding */
-    padding: 0 16px;
     background: linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 60%, rgba(255,255,255,1) 100%);
     transition: opacity 0.3s;
   }
-  .toc-scroll-fade.hidden {
+  .toc-scroll-fade {
+    margin: 0 -16px;           /* stretch to fill #page-toc padding */
+    padding: 0 16px;
+  }
+  .toc-scroll-fade.hidden,
+  .sidebar-scroll-fade.hidden {
     opacity: 0;
   }
   #page-toc h3 {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -92,20 +92,6 @@
     <script src="{{"js/altinndocs.js" | relURL}}"></script>
     <script src="{{"js/altinndocs-learn.js" | relURL}}"></script>
 
-    <script src="{{"js/stickysidebar/rAF.js" | relURL}}"></script>
-    <script src="{{"js/stickysidebar/ResizeSensor.js" | relURL}}"></script>
-    <script src="{{"js/stickysidebar/sticky-sidebar.js" | relURL}}"></script>
-    
-    <script>
-      var a = new StickySidebar('#sidebar', {
-        topSpacing: 20,
-        bottomSpacing: 60,
-        containerSelector: '.adocs-scrollcontainer',
-        innerWrapperSelector: '.sidebar__inner',
-        minWidth: 768
-      });
-    </script>
-
     <link href="{{"mermaid/mermaid.css" | relURL}}" type="text/css" rel="stylesheet"/>
     <script src="{{"mermaid/mermaid.js" | relURL}}"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
@@ -113,20 +99,25 @@
     {{ partial "custom-footer.html" . }}
 
     <script>
-    // TOC scroll-hint: hide fade when scrolled to bottom, show when more content below
+    // Scroll-hint fade for TOC and sidebar
     (function() {
-      var toc = document.getElementById('page-toc');
-      if (!toc) return;
-      var fade = toc.querySelector('.toc-scroll-fade');
-      if (!fade) return;
-      function update() {
-        var atBottom = toc.scrollHeight - toc.scrollTop - toc.clientHeight < 4;
-        var noOverflow = toc.scrollHeight <= toc.clientHeight;
-        fade.classList.toggle('hidden', atBottom || noOverflow);
+      function setupFade(container, fadeSelector) {
+        if (!container) return;
+        var fade = container.querySelector(fadeSelector);
+        if (!fade) return;
+        function update() {
+          var atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 4;
+          var noOverflow = container.scrollHeight <= container.clientHeight;
+          fade.classList.toggle('hidden', atBottom || noOverflow);
+        }
+        container.addEventListener('scroll', update);
+        window.addEventListener('resize', update);
+        // Re-check when menu items expand/collapse (height changes)
+        new MutationObserver(update).observe(container, { childList: true, subtree: true, attributes: true });
+        update();
       }
-      toc.addEventListener('scroll', update);
-      window.addEventListener('resize', update);
-      update();
+      setupFade(document.getElementById('page-toc'), '.toc-scroll-fade');
+      setupFade(document.getElementById('sidebar'), '.sidebar-scroll-fade');
     })();
     </script>
 

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -38,6 +38,7 @@
 
         {{end}}
     </ul>
+  <div class="sidebar-scroll-fade" aria-hidden="true"></div>
   </div>
 </nav>
 


### PR DESCRIPTION
- Gjør #sidebar sticky med position:sticky + overflow-y:auto + max-height:90vh
- Skjuler scrollbar helt (som TOC)
- Legger til gradient fade scroll-hint i bunnen av sidebar
- Fjerner StickySidebar JS-bibliotek (erstattet av ren CSS sticky)
- Delt JS som håndterer fade for både TOC og sidebar
- MutationObserver oppdaterer faden ved expand/collapse av menyemner

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx