### PR TITLE
Fix sidebar fade: overstyr .highlightable overflow så #sidebar eier s…

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -287,6 +287,11 @@
     #sidebar::-webkit-scrollbar {
       display: none;                      /* Chrome/Safari */
     }
+    /* Override theme.css .highlightable so #sidebar owns the scroll */
+    #sidebar .highlightable {
+      overflow: visible;
+      height: auto;
+    }
     .body-toc-wrapper {
       flex: 1;
       min-width: 0;


### PR DESCRIPTION
…croll

Theme.css gir .highlightable overflow:auto og height:100% som lager en konkurrerende scroll-kontekst. Overstyrer til overflow:visible / height:auto slik at #sidebar er den faktiske scroll-containeren og position:sticky faden fungerer korrekt.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx