### PR TITLE
Fix sidebar fade: bruk ::after pseudo-element som direkte barn av scr…

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -344,22 +344,34 @@
     display: none;                        /* Chrome/Safari */
   }
   /* Scroll-hint: gradient fade at bottom when more content below */
-  .toc-scroll-fade,
-  .sidebar-scroll-fade {
+  .toc-scroll-fade {
     pointer-events: none;
     position: sticky;
     bottom: 0;
     display: block;
     height: 36px;
+    margin: 0 -16px;           /* stretch to fill #page-toc padding */
+    padding: 0 16px;
     background: linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 60%, rgba(255,255,255,1) 100%);
     transition: opacity 0.3s;
   }
-  .toc-scroll-fade {
-    margin: 0 -16px;           /* stretch to fill #page-toc padding */
-    padding: 0 16px;
+  .toc-scroll-fade.hidden {
+    opacity: 0;
   }
-  .toc-scroll-fade.hidden,
-  .sidebar-scroll-fade.hidden {
+  /* Sidebar fade: pseudo-element = direct child of scroll container */
+  #sidebar::after {
+    content: '';
+    pointer-events: none;
+    position: sticky;
+    bottom: 0;
+    display: block;
+    height: 36px;
+    margin-top: -36px;
+    background: linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 60%, rgba(255,255,255,1) 100%);
+    transition: opacity 0.3s;
+    z-index: 1;
+  }
+  #sidebar.fade-hidden::after {
     opacity: 0;
   }
   #page-toc h3 {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -99,25 +99,36 @@
     {{ partial "custom-footer.html" . }}
 
     <script>
-    // Scroll-hint fade for TOC and sidebar
+    // Scroll-hint fade for TOC (uses child div) and sidebar (uses ::after pseudo-element)
     (function() {
-      function setupFade(container, fadeSelector) {
-        if (!container) return;
-        var fade = container.querySelector(fadeSelector);
-        if (!fade) return;
-        function update() {
-          var atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 4;
-          var noOverflow = container.scrollHeight <= container.clientHeight;
-          fade.classList.toggle('hidden', atBottom || noOverflow);
+      // TOC: toggle .hidden on the fade div
+      var toc = document.getElementById('page-toc');
+      if (toc) {
+        var tocFade = toc.querySelector('.toc-scroll-fade');
+        if (tocFade) {
+          function updateToc() {
+            var atBottom = toc.scrollHeight - toc.scrollTop - toc.clientHeight < 4;
+            var noOverflow = toc.scrollHeight <= toc.clientHeight;
+            tocFade.classList.toggle('hidden', atBottom || noOverflow);
+          }
+          toc.addEventListener('scroll', updateToc);
+          window.addEventListener('resize', updateToc);
+          updateToc();
         }
-        container.addEventListener('scroll', update);
-        window.addEventListener('resize', update);
-        // Re-check when menu items expand/collapse (height changes)
-        new MutationObserver(update).observe(container, { childList: true, subtree: true, attributes: true });
-        update();
       }
-      setupFade(document.getElementById('page-toc'), '.toc-scroll-fade');
-      setupFade(document.getElementById('sidebar'), '.sidebar-scroll-fade');
+      // Sidebar: toggle .fade-hidden on #sidebar itself (controls ::after)
+      var sb = document.getElementById('sidebar');
+      if (sb) {
+        function updateSb() {
+          var atBottom = sb.scrollHeight - sb.scrollTop - sb.clientHeight < 4;
+          var noOverflow = sb.scrollHeight <= sb.clientHeight;
+          sb.classList.toggle('fade-hidden', atBottom || noOverflow);
+        }
+        sb.addEventListener('scroll', updateSb);
+        window.addEventListener('resize', updateSb);
+        new MutationObserver(updateSb).observe(sb, { childList: true, subtree: true, attributes: true });
+        updateSb();
+      }
     })();
     </script>
 

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -38,7 +38,6 @@
 
         {{end}}
     </ul>
-  <div class="sidebar-scroll-fade" aria-hidden="true"></div>
   </div>
 </nav>
 


### PR DESCRIPTION
…oll-container

Forrige tilnærming plasserte fade-div'en inne i .highlightable (barnebarn av scroll-containeren #sidebar). position:sticky bottom:0 fungerer ikke pålitelig på den avstanden.

Ny tilnærming: #sidebar::after pseudo-element er et direkte barn av scroll-containeren, slik at sticky bottom:0 alltid fungerer. JS toggler .fade-hidden klasse på #sidebar i stedet for .hidden på et underliggende element.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx