### PR TITLE
Tre uavhengige scroll-paneler: sidebar, innhold og TOC

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -265,22 +265,49 @@
     border: none !important;
   }
 
-  /* 3-column proportional flex layout: sidebar | content | TOC
-     Uses percentages so column ratios hold when zooming */
+  /* 3-column independent-scroll layout: sidebar | content | TOC
+     Each column scrolls on its own; the page itself does NOT scroll.
+     Header and footer stay fixed at top/bottom of the viewport. */
   @media (min-width: 768px) {
+    /* Lock the viewport — no page-level scroll */
+    html, body.a-page {
+      height: 100%;
+      overflow: hidden;
+    }
+    body.a-page {
+      display: flex;
+      flex-direction: column;
+    }
+    /* Header / footer keep their natural size */
+    .a-jumpnav, .a-header, .a-footer { flex-shrink: 0; }
+
+    /* Container between header and footer fills remaining space */
+    body.a-page > .container {
+      flex: 1;
+      min-height: 0;           /* allow flex child to shrink below content */
+      display: flex;
+      flex-direction: column;
+    }
+    .adocs-scrollcontainer {
+      flex: 1;
+      min-height: 0;
+    }
+    .adocs-scrollcontainer .row {
+      height: 100%;
+    }
     .adocs-scrollcontainer .row > .col-sm-12 {
       display: flex;
-      align-items: flex-start;
+      align-items: stretch;    /* columns fill full height */
+      height: 100%;
     }
+
+    /* --- Left column: sidebar --- */
     #sidebar {
       float: none !important;
       flex: 0 0 20%;
       min-width: 180px;
       max-width: 260px;
       font-size: 15px;
-      position: sticky;
-      top: 20px;
-      max-height: 90vh;
       overflow-y: auto;
       scrollbar-width: none;             /* Firefox */
     }
@@ -292,17 +319,35 @@
       overflow: visible;
       height: auto;
     }
+
+    /* --- Middle + right wrapper --- */
     .body-toc-wrapper {
       flex: 1;
       min-width: 0;
+      min-height: 0;
       display: flex;
-      align-items: flex-start;
+      align-items: stretch;
       margin-left: 16px;
     }
+
+    /* --- Middle column: main content --- */
     .body-toc-wrapper #body {
       flex: 1;
       min-width: 0;
+      overflow-y: auto;
       margin-left: 0 !important;
+    }
+
+    /* --- Right column: table of contents --- */
+    #page-toc {
+      flex: 0 0 18%;
+      min-width: 150px;
+      max-width: 240px;
+      overflow-y: auto;
+      scrollbar-width: none;             /* Firefox */
+    }
+    #page-toc::-webkit-scrollbar {
+      display: none;                      /* Chrome/Safari */
     }
   }
 
@@ -324,24 +369,12 @@
     padding-left: 16px;
   }
 
-  /* Right-side Table of Contents */
+  /* Right-side Table of Contents (visual styling only; layout in @media above) */
   #page-toc {
-    position: sticky;
-    top: 20px;
-    flex: 0 0 18%;
-    min-width: 150px;
-    max-width: 240px;
     padding: 12px 16px;
     margin-left: 16px;
     font-size: 13px;
     border-left: 2px solid #e0e0e0;
-    max-height: 85vh;
-    overflow-y: auto;
-    /* Completely hidden scrollbar */
-    scrollbar-width: none;               /* Firefox */
-  }
-  #page-toc::-webkit-scrollbar {
-    display: none;                        /* Chrome/Safari */
   }
   /* Scroll-hint: gradient fade at bottom when more content below */
   .toc-scroll-fade {


### PR DESCRIPTION
Erstatter sticky-kolonne-i-scrollende-side med tre helt uavhengige scroll-paneler som fyller viewporten:

- body blir flex-kolonne: header | tre-kolonner | footer
- Hver kolonne fyller tilgjengelig høyde og scroller for seg selv
- Fjerner position:sticky og max-height fra sidebar og TOC
- Midtre kolonne (#body) får overflow-y:auto for egen scroll
- Header og footer forblir synlige, utenfor scroll-konteksten
- Mobil (< 768px) beholder normal sideflyt som før

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx