### PR TITLE
Sidebar-overskrift: 'Temaer' → 'INNHOLD' / 'CONTENTS', alignment-fix

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -308,6 +308,7 @@
       min-width: 180px;
       max-width: 260px;
       font-size: 15px;
+      padding-top: 12px;               /* vertical align with TOC heading */
       overflow-y: auto;
       scrollbar-width: none;             /* Firefox */
     }
@@ -359,14 +360,14 @@
     padding: 2px 6px !important;
   }
 
-  /* Left sidebar heading (matches #page-toc h3) */
+  /* Left sidebar heading — aligned with menu items and TOC heading */
   #sidebar .sidebar-heading {
     font-size: 14px;
     font-weight: bold;
     margin-top: 0;
-    margin-bottom: 8px;
+    margin-bottom: 4px;
     color: #333;
-    padding-left: 16px;
+    padding-left: 9px;          /* flush with menu-item text (2px + 9px padding on <a>) */
   }
 
   /* Right-side Table of Contents (visual styling only; layout in @media above) */

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -7,7 +7,7 @@
 <div class="highlightable">
   <div id="header-wrapper">
   </div>
-  <h3 class="sidebar-heading">{{ cond (eq .Site.Language.Lang "nb") "Temaer" "Topics" }}</h3>
+  <h3 class="sidebar-heading">{{ cond (eq .Site.Language.Lang "nb") "INNHOLD" "CONTENTS" }}</h3>
 
     <ul id="docsmenu" class="topics">
 


### PR DESCRIPTION
- Endrer overskrift fra «Temaer»/«Topics» til «INNHOLD»/«CONTENTS»
- Horisontal: padding-left 16px → 9px, flukter med menypunktene
- Vertikal: padding-top 12px på sidebar, matcher TOC-heading
- Reduserer margin-bottom 8px → 4px mellom heading og første menylinje

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx