### PR TITLE
Fjern overflødig avstand mellom INNHOLD-heading og første menylinje

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -365,9 +365,13 @@
     font-size: 14px;
     font-weight: bold;
     margin-top: 0;
-    margin-bottom: 4px;
+    margin-bottom: 2px;           /* symmetric with padding above first menu item */
     color: #333;
-    padding-left: 9px;          /* flush with menu-item text (2px + 9px padding on <a>) */
+    padding-left: 9px;            /* flush with menu-item text */
+  }
+  /* Override theme's 36px margin-top so heading↔line↔menu spacing is tight */
+  #sidebar ul.topics {
+    margin-top: 0 !important;
   }
 
   /* Right-side Table of Contents (visual styling only; layout in @media above) */


### PR DESCRIPTION
- Override tema-CSS margin-top: 36px → 0 på ul.topics
- Heading margin-bottom: 4px → 2px
- Symmetrisk avstand over og under separator-streken (2px begge sider)

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx