### PR TITLE
Reduser header-høyde med ~1/3, behold innhold vertikalt midtstilt

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -281,6 +281,21 @@
     /* Header / footer keep their natural size */
     .a-jumpnav, .a-header, .a-footer { flex-shrink: 0; }
 
+    /* Reduce header height by ~1/3 (100px → ~66px), keep content centered */
+    .a-header {
+      height: auto !important;
+      padding-top: 0 !important;
+      padding-bottom: 0 !important;
+    }
+    .a-header .container,
+    .a-header .row,
+    .a-header .col-12 {
+      height: 100%;
+    }
+    .a-header #primary-nav {
+      padding: 13px 0;           /* ~66px total with 40px logo */
+    }
+
     /* Container between header and footer fills remaining space */
     body.a-page > .container {
       flex: 1;


### PR DESCRIPTION
Override tema-CSS height: 100px → auto, fjern padding-top: 32px, erstatt med symmetrisk padding (13px) på nav-elementet. Gir ~66px total høyde mot 100px tidligere.

https://claude.ai/code/session_01MEzt4XbNteA4JhRNYZuVKx