### PR TITLE
Legg til KS FoU 256060 – Leverandørmarkedet for digitale løsninger

### DIFF
--- a/content/innsikt/fou-rapporter/ks-fou-256060-leverandormarkedet/_index.en.md
+++ b/content/innsikt/fou-rapporter/ks-fou-256060-leverandormarkedet/_index.en.md
@@ -1,0 +1,48 @@
+---
+# id: auto-generert – kopierte verdier overskrives automatisk ved push
+title: "KS Research Report 256060 – The Supplier Market for Digital Solutions in the Municipal Sector"
+linkTitle: "KS R&D 256060 – Supplier Market"
+weight: 10
+
+---
+
+## About the report
+
+**Source:** [KS R&D Report 256060 – Oslo Economics and Capto](https://www.ks.no/fagomrader/forskning-og-utvikling-fou/fou-rapporter/digitalisering-hvordan-fungerer-leverandormarkedet/)\
+**Commissioned by:** KS\
+**Conducted by:** Oslo Economics and Capto
+
+**The report maps and analyses the supplier market for digital solutions in the Norwegian municipal sector, with deep dives into three market areas: administrative systems (ERP), welfare technology, and ePlanSak. The aim is to strengthen municipalities' market position and improve the relationship with suppliers.**
+
+### Key findings
+
+- **Concentrated market with limited competition:** Municipalities hold hundreds of digital solutions, but most market areas are dominated by one to three major suppliers – including Visma, Tieto, Crayon, and Atea – leaving few real alternatives in procurement processes.
+
+- **Unwanted lock-in:** Municipalities experience a lack of transparency into key solution properties, creating high switching costs and reducing their leverage at contract renewal.
+
+- **Untapped bargaining power:** The report concludes that the municipal sector likely has more bargaining power than it realises or exercises. Regional and national coordination is the key to activating this power.
+
+- **Fragmented demand side:** Suppliers experience municipalities as uncoordinated, with diverging requirements and unclear priorities, which hampers innovation and the scaling of new solutions.
+
+- **Varying procurement competence:** Municipalities' ability to conduct effective procurement varies significantly, and many make too little use of open specifications and market dialogue.
+
+### Recommendations
+
+The report recommends that the municipal sector:
+
+1. Increases coordination – regionally and through KS/KS Digital – to strengthen its negotiating position vis-à-vis suppliers
+2. Conducts more systematic market dialogue and develops more open specifications focused on needs and value realisation
+3. Demands greater transparency from suppliers regarding technical properties, integration interfaces, and data portability principles
+4. Enables more suppliers – including smaller actors – to participate in procurement competitions
+
+---
+
+[👉 Download the report (PDF) from KS.no](https://www.ks.no/contentassets/c9d728f1b6e74d179ab76d15d311f237/Oslo-Economics-og-Capto-KS-FoU-256060-Leverandormarkedet-for-digitale-losninger-til-kommunal-sektor.pdf)
+
+## Relevance for SAMT-BU
+
+1. The report documents structural market challenges that directly affect municipalities' room for manoeuvre in SAMT-BU pilots: lock-in to legacy systems, the absence of open APIs, and weak data portability are among the concrete barriers to data-driven cross-sector collaboration.
+
+2. The recommendations on coordination and open specifications align with the SAMT-BU approach of shifting power from suppliers to the sector through shared information models and standards for data sharing.
+
+3. Use case 15 (Procurement of professional systems) can usefully draw on the findings of this report – particularly around requirements for open interfaces and avoiding lock-in as a prerequisite for coherent services.

--- a/content/innsikt/fou-rapporter/ks-fou-256060-leverandormarkedet/_index.nb.md
+++ b/content/innsikt/fou-rapporter/ks-fou-256060-leverandormarkedet/_index.nb.md
@@ -1,0 +1,48 @@
+---
+# id: auto-generert – kopierte verdier overskrives automatisk ved push
+title: "KS FoU 256060 – Leverandørmarkedet for digitale løsninger til kommunal sektor"
+linkTitle: "KS FoU 256060 – Leverandørmarkedet"
+weight: 10
+
+---
+
+## Om rapporten
+
+**Kilde:** [KS FoU-rapport 256060 – Oslo Economics og Capto](https://www.ks.no/fagomrader/forskning-og-utvikling-fou/fou-rapporter/digitalisering-hvordan-fungerer-leverandormarkedet/)\
+**Oppdragsgiver:** KS\
+**Utført av:** Oslo Economics og Capto
+
+**Rapporten kartlegger og analyserer leverandørmarkedet for digitale løsninger i kommunal sektor, med dypdykk i tre markedsområder: administrative løsninger (ERP), velferdsteknologi og ePlanSak. Formålet er å styrke kommunenes markedsposisjon og bidra til et mer velfungerende samspill med leverandørene.**
+
+### Hovedfunn
+
+- **Konsentrert marked med begrenset konkurranse:** Kommuner og fylkeskommuner har flere hundre digitale løsninger i porteføljen, men innenfor de fleste markedsområder dominerer én til tre store aktører – blant dem Visma, Tieto, Crayon og Atea. Dette gir i praksis få reelle alternativer i anskaffelser.
+
+- **Uønsket innlåsing:** Kommunene opplever manglende innsyn i sentrale egenskaper ved løsningene, noe som skaper høye byttekostnader og svekker handlingsrommet ved kontraktsfornyelser.
+
+- **Uutnyttet forhandlingsmakt:** Rapporten konkluderer med at kommunesektoren trolig har mer forhandlingsmakt enn den er klar over og faktisk utøver. Samordning mellom kommuner regionalt og nasjonalt er nøkkelen til å aktivere denne kraften.
+
+- **Fragmentert etterspørselsside:** Leverandørene opplever kommunene som ukoordinerte, med sprikende krav og uklare prioriteringer, noe som hemmer innovasjon og skalering av nye løsninger.
+
+- **Varierende anskaffelseskompetanse:** Kommunenes forutsetninger for å gjennomføre gode anskaffelser varierer betydelig, og mange bruker for lite åpne kravspesifikasjoner og markedsdialog.
+
+### Anbefalinger
+
+Rapporten anbefaler at kommunesektoren:
+
+1. Øker samordningen – regionalt og gjennom KS/KS Digital – for å styrke forhandlingsposisjonen overfor leverandørene
+2. Gjennomfører mer systematisk markedsdialog og utarbeider åpnere kravspesifikasjoner med fokus på behov og gevinstrealisering
+3. Krever økt transparens fra leverandørene om løsningenes tekniske egenskaper, integrasjonsgrensesnitt og prinsipp for dataportabilitet
+4. Legger til rette for at flere leverandører – også mindre aktører – kan delta i konkurranser
+
+---
+
+[👉 Last ned rapporten (PDF) fra KS.no](https://www.ks.no/contentassets/c9d728f1b6e74d179ab76d15d311f237/Oslo-Economics-og-Capto-KS-FoU-256060-Leverandormarkedet-for-digitale-losninger-til-kommunal-sektor.pdf)
+
+## Relevans for SAMT-BU
+
+1. Rapporten dokumenterer strukturelle markedsutfordringer som direkte påvirker kommunenes handlingsrom i SAMT-BU-piloter: innlåsing i fagsystemer, manglende åpne API-er og svak dataportabilitet er blant de konkrete hindrene for datadrevet samhandling på tvers av sektorer.
+
+2. Anbefalingene om samordning og åpne kravspesifikasjoner harmonerer med SAMT-BU-tilnærmingen om å flytte makt fra leverandør til sektor gjennom felles informasjonsmodeller og standarder for datadeling.
+
+3. Use case 15 (Anskaffelser av fagsystemer) kan med fordel koble seg på funnene i denne rapporten – særlig rundt krav til åpne grensesnitt og unngåelse av innlåsing som forutsetning for sammenhengende tjenester.


### PR DESCRIPTION
## Hva er endret

Ny underside under `innsikt/fou-rapporter/` med oppsummering av KS FoU-rapport 256060 (Oslo Economics og Capto).

- `_index.nb.md` – norsk oppsummering med hovedfunn, anbefalinger og relevans for SAMT-BU
- `_index.en.md` – engelsk oversettelse

## Innhold

Rapporten kartlegger leverandørmarkedet for digitale løsninger i kommunal sektor (ERP, velferdsteknologi, ePlanSak). Nøkkelfunn: konsentrert marked, innlåsingsrisiko, uutnyttet forhandlingsmakt og varierende anskaffelseskompetanse.

Koblingen til SAMT-BU: innlåsing i fagsystemer og manglende åpne API-er er direkte barrierer for datadrevet samhandling på tvers av sektorer.